### PR TITLE
T4235: simplify return value of diff_tree

### DIFF
--- a/src/config_diff.mli
+++ b/src/config_diff.mli
@@ -13,9 +13,9 @@ type diff_trees = {
 exception Incommensurable
 exception Empty_comparison
 
-val make_diff_tree : Config_tree.t -> Config_tree.t -> diff_trees
+val make_diff_trees : Config_tree.t -> Config_tree.t -> diff_trees
 val clone : ?with_children:bool -> ?set_values:string list -> Config_tree.t -> Config_tree.t -> string list -> Config_tree.t
 val decorate_trees : diff_trees -> ?with_children:bool -> string list -> change -> unit
 val compare : string list -> Config_tree.t -> Config_tree.t -> diff_trees
-val diffs : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t * Config_tree.t * Config_tree.t
+val diff_tree : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t
 

--- a/src/config_tree.ml
+++ b/src/config_tree.ml
@@ -101,6 +101,15 @@ let is_tag node path =
     let data = Vytree.get_data node path in
     data.tag
 
+let get_subtree ?(with_node=false) node path =
+    try
+        let n = Vytree.get node path in
+        if with_node then
+            Vytree.make_full default_data "root" [n]
+        else
+            Vytree.make_full default_data "root" (Vytree.children_of_node n)
+    with Vytree.Nonexistent_path -> make "root"
+
 module Renderer =
 struct
     (* Rendering configs as set commands *)

--- a/src/config_tree.mli
+++ b/src/config_tree.mli
@@ -34,6 +34,8 @@ val set_tag : t -> string list -> bool -> t
 
 val is_tag : t -> string list -> bool
 
+val get_subtree : ?with_node:bool -> t -> string list -> t
+
 val render_commands : ?op:command -> t -> string list -> string
 
 val render_config : t -> string


### PR DESCRIPTION
Drop the use of Ctypes.CArray and return a config_tree with initial nodes of name ["add"; "delete"; "inter"] containing the respective sub-trees; add utility function get_subtree; drop improper trimming of delete paths.