### PR TITLE
T4235: distinguish between sub(-tract) tree and delete tree

### DIFF
--- a/src/config_diff.mli
+++ b/src/config_diff.mli
@@ -1,6 +1,6 @@
-type change = Unchanged | Added | Deleted | Updated of string list
+type change = Unchanged | Added | Subtracted | Updated of string list
 
-type diff_func = ?with_children:bool -> string list -> change -> unit
+type diff_func = ?recurse:bool -> string list -> change -> unit
 
 type diff_trees = {
     left: Config_tree.t;
@@ -14,8 +14,8 @@ exception Incommensurable
 exception Empty_comparison
 
 val make_diff_trees : Config_tree.t -> Config_tree.t -> diff_trees
-val clone : ?with_children:bool -> ?set_values:string list -> Config_tree.t -> Config_tree.t -> string list -> Config_tree.t
-val decorate_trees : diff_trees -> ?with_children:bool -> string list -> change -> unit
+val clone : ?recurse:bool -> ?set_values:string list -> Config_tree.t -> Config_tree.t -> string list -> Config_tree.t
+val decorate_trees : diff_trees -> ?recurse:bool -> string list -> change -> unit
 val compare : string list -> Config_tree.t -> Config_tree.t -> diff_trees
 val diff_tree : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t
 

--- a/src/config_diff.mli
+++ b/src/config_diff.mli
@@ -13,9 +13,9 @@ type diff_trees = {
 exception Incommensurable
 exception Empty_comparison
 
-val make_diff_tree : Config_tree.t -> Config_tree.t -> diff_trees
+val make_diff_trees : Config_tree.t -> Config_tree.t -> diff_trees
 val clone : ?with_children:bool -> ?set_values:string list -> Config_tree.t -> Config_tree.t -> string list -> Config_tree.t
 val decorate_trees : diff_trees -> ?with_children:bool -> string list -> change -> unit
 val compare : string list -> Config_tree.t -> Config_tree.t -> diff_trees
-val diffs : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t * Config_tree.t * Config_tree.t
+val diff_tree : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t
 

--- a/src/config_diff.mli
+++ b/src/config_diff.mli
@@ -14,8 +14,10 @@ exception Incommensurable
 exception Empty_comparison
 
 val make_diff_trees : Config_tree.t -> Config_tree.t -> diff_trees
-val clone : ?recurse:bool -> ?set_values:string list -> Config_tree.t -> Config_tree.t -> string list -> Config_tree.t
+val clone : ?recurse:bool -> ?set_values:(string list) option -> Config_tree.t -> Config_tree.t -> string list -> Config_tree.t
 val decorate_trees : diff_trees -> ?recurse:bool -> string list -> change -> unit
+val trim_trees : diff_trees -> ?recurse:bool -> string list -> change -> unit
 val compare : string list -> Config_tree.t -> Config_tree.t -> diff_trees
 val diff_tree : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t
+val trim_tree : Config_tree.t -> Config_tree.t -> Config_tree.t
 

--- a/src/config_diff.mli
+++ b/src/config_diff.mli
@@ -6,7 +6,7 @@ type diff_trees = {
     left: Config_tree.t;
     right: Config_tree.t;
     add: Config_tree.t ref;
-    del: Config_tree.t ref;
+    sub: Config_tree.t ref;
     inter: Config_tree.t ref;
 }
 

--- a/src/config_tree.ml
+++ b/src/config_tree.ml
@@ -101,6 +101,15 @@ let is_tag node path =
     let data = Vytree.get_data node path in
     data.tag
 
+let get_subtree ?(with_node=false) node path =
+    try
+        let n = Vytree.get node path in
+        if with_node then
+            Vytree.make_full default_data "root" [n]
+        else
+            Vytree.make_full default_data "root" (Vytree.children_of_node n)
+    with Vytree.Nonexistent_path -> make "root"
+
 module Renderer =
 struct
     (* Rendering configs as set commands *)

--- a/src/config_tree.mli
+++ b/src/config_tree.mli
@@ -34,6 +34,8 @@ val set_tag : t -> string list -> bool -> t
 
 val is_tag : t -> string list -> bool
 
+val get_subtree : ?with_node:bool -> t -> string list -> t
+
 val render_commands : ?op:command -> t -> string list -> string
 
 val render_config : t -> string


### PR DESCRIPTION
The diff_tree function produces a configtree containing subtrees 'add', 'sub', 'inter'. The 'sub'(-tract) tree contains the full paths present in the LHS that are not present in the RHS. By contrast, the 'delete' configtree is a minimal subtree of 'sub' sufficient for producing CLI delete commands; the tree is obtained by applying the function 'trim_tree' to (sub, rhs).

This PR is rebased over that of
https://github.com/vyos/vyos1x-config/pull/3
