### PR TITLE
T4334: make the lexer reentrant by passing state around instead of using a shared mutable reference

### DIFF
--- a/src/parser.ml
+++ b/src/parser.ml
@@ -3,18 +3,18 @@ open Lexing
 
 module I = Vyos1x_parser.MenhirInterpreter
 
-let rec parse lexbuf (checkpoint : Config_tree.t I.checkpoint) =
+let rec parse vy_inside_node lexbuf (checkpoint : Config_tree.t I.checkpoint) =
   match checkpoint with
   | I.InputNeeded _env ->
-      let token = Vyos1x_lexer.token lexbuf in
+      let vy_inside_node, token = Vyos1x_lexer.token vy_inside_node lexbuf in
       let startp = lexbuf.lex_start_p
       and endp = lexbuf.lex_curr_p in
       let checkpoint = I.offer checkpoint (token, startp, endp) in
-      parse lexbuf checkpoint
+      parse vy_inside_node lexbuf checkpoint
   | I.Shifting _
   | I.AboutToReduce _ ->
       let checkpoint = I.resume checkpoint in
-      parse lexbuf checkpoint
+      parse vy_inside_node lexbuf checkpoint
   | I.HandlingError _env ->
       let line, pos = Util.get_lexing_position lexbuf in
       raise (Syntax_error (Some (line, pos), "Invalid syntax."))
@@ -23,5 +23,6 @@ let rec parse lexbuf (checkpoint : Config_tree.t I.checkpoint) =
        raise (Syntax_error (None, "invalid syntax (parser rejected the input)"))
 
 let from_string s =
+  let vy_inside_node = false in
   let lexbuf = Lexing.from_string s in
-  parse lexbuf (Vyos1x_parser.Incremental.config lexbuf.lex_curr_p)
+  parse vy_inside_node lexbuf (Vyos1x_parser.Incremental.config lexbuf.lex_curr_p)


### PR DESCRIPTION
The lexer requires state tracking (a lexer hack) to tell leaf node values and tag nodes apart. The original implementation used a shared mutable reference, which made the lexer non-reentrant (and thus not thread-safe).

This implementation uses a lexing function argument for passing the state around between calls, so it doesn't rely on any shared memory anymore.