### PR TITLE
T4491: use empty string for name of config_tree root node

### DIFF
--- a/src/config_diff.ml
+++ b/src/config_diff.ml
@@ -16,9 +16,9 @@ exception Empty_comparison
 module ValueS = Set.Make(struct type t = string let compare = compare end)
 
 let make_diff_trees l r = { left = l; right = r;
-                           add = ref (Config_tree.make "root");
-                           sub = ref (Config_tree.make "root");
-                           inter = ref (Config_tree.make "root");
+                           add = ref (Config_tree.make "");
+                           sub = ref (Config_tree.make "");
+                           inter = ref (Config_tree.make "");
 }
 
 let name_of n = Vytree.name_of_node n
@@ -56,7 +56,7 @@ let get_opt_name left_opt right_opt =
 
 let update_path path left_opt right_opt =
     let name = get_opt_name left_opt right_opt in
-    if name = "root" then path
+    if name = "" then path
     else path @ [name]
 
 (* tree diff algorithm: walk the tree pair, calling a function of type
@@ -198,7 +198,7 @@ let trim_trees (trees : diff_trees) ?(recurse=false) (path : string list) (m : c
 let tree_at_path path node =
     try
         let node = Vytree.get node path in
-        make Config_tree.default_data "root" [node]
+        make Config_tree.default_data "" [node]
     with Vytree.Nonexistent_path -> raise Empty_comparison
 
 (* call recursive diff on config_trees with decorate_trees as the diff_func *)
@@ -218,7 +218,7 @@ let diff_tree path left right =
     let add_node = Config_tree.make "add" in
     let sub_node = Config_tree.make "sub" in
     let int_node = Config_tree.make "inter" in
-    let ret = make Config_tree.default_data "root" [add_node; sub_node; int_node] in
+    let ret = make Config_tree.default_data "" [add_node; sub_node; int_node] in
     let ret = graft_tree !(trees.add) ret ["add"] in
     let ret = graft_tree !(trees.sub) ret ["sub"] in
     let ret = graft_tree !(trees.inter) ret ["inter"] in

--- a/src/config_tree.ml
+++ b/src/config_tree.ml
@@ -105,10 +105,10 @@ let get_subtree ?(with_node=false) node path =
     try
         let n = Vytree.get node path in
         if with_node then
-            Vytree.make_full default_data "root" [n]
+            Vytree.make_full default_data "" [n]
         else
-            Vytree.make_full default_data "root" (Vytree.children_of_node n)
-    with Vytree.Nonexistent_path -> make "root"
+            Vytree.make_full default_data "" (Vytree.children_of_node n)
+    with Vytree.Nonexistent_path -> make ""
 
 module Renderer =
 struct

--- a/src/vyos1x_parser.mly
+++ b/src/vyos1x_parser.mly
@@ -103,7 +103,7 @@ node_content: n = node { n } | n = leaf_node { n } | n = tag_node { n };
 %public config:
  | ns = list(node_content); EOF
  {
-    let root = make "root" in
+    let root = make "" in
     let root = List.fold_left Vytree.adopt root (List.rev ns) |> Vytree.merge_children merge_data in
         try
             List.iter find_duplicate_children (Vytree.children_of_node root);


### PR DESCRIPTION
The practice of using "root" for the internal name of the root node
collides with actual nodes named "root", due to a utility function that
checks 'if root' by name. Use empty string as name of root node, as no
actual node will match.