### PR TITLE
T4628: render tag node names containing whitespace in quotes

### DIFF
--- a/src/config_tree.ml
+++ b/src/config_tree.ml
@@ -211,7 +211,9 @@ struct
            never themselves tag nodes *)
         let inner = List.map (render_node indent (level + 1)) children in
         let inner = String.concat "" inner in
-        Printf.sprintf "%s%s%s %s {\n%s%s}\n" comment indent_str parent name inner indent_str
+        if String.contains name ' ' then
+        Printf.sprintf "%s%s%s \"%s\" {\n%s%s}\n" comment indent_str parent name inner indent_str
+        else Printf.sprintf "%s%s%s %s {\n%s%s}\n" comment indent_str parent name inner indent_str
 
   let render_config node =
     let children = Vytree.children_of_node node in


### PR DESCRIPTION
If tag node names contain whitespace, they should be rendered in quotes in to_string(); otherwise, on a subsequent read, parsing will fail.