### PR TITLE
T4961: add name of offending node in exception Insert_error of string

### DIFF
--- a/src/vytree.ml
+++ b/src/vytree.ml
@@ -83,7 +83,8 @@ let rec insert ?(position=Default) ?(children=[]) node path data =
             let new_node = insert ~position:position ~children:children next_child' names data in
             replace node new_node
         | None ->
-            raise (Insert_error "Path does not exist")
+            let s = Printf.sprintf "Non-existent intermediary node: \'%s\'" name in
+            raise (Insert_error s)
 
 (** Given a node N check if it has children with duplicate names,
     and merge subsequent children's children into the first child by


### PR DESCRIPTION
Following from
https://phabricator.vyos.net/T4961
and PR:
https://github.com/vyos/libvyosconfig/pull/6
add node name to `exception Insert_error of string`