### PR TITLE
T5089: support for unit test of config_diff

### DIFF
--- a/src/config_diff.ml
+++ b/src/config_diff.ml
@@ -12,13 +12,7 @@ type diff_trees = {
 
 exception Incommensurable
 exception Empty_comparison
-
-module ValueOrd = struct
-    type t = string
-    let compare a b =
-        Util.lexical_numeric_compare a b
-end
-module ValueS = Set.Make(ValueOrd)
+exception Nonexistent_child
 
 let make_diff_trees l r = { left = l; right = r;
                            add = ref (Config_tree.make "");
@@ -30,6 +24,20 @@ let name_of n = Vytree.name_of_node n
 let data_of n = Vytree.data_of_node n
 let children_of n = Vytree.children_of_node n
 let make data name children = Vytree.make_full data name children
+
+module ValueOrd = struct
+    type t = string
+    let compare a b =
+        Util.lexical_numeric_compare a b
+end
+module ValueS = Set.Make(ValueOrd)
+
+module TreeOrd = struct
+    type t = Config_tree.t
+    let compare a b =
+        Util.lexical_numeric_compare (name_of a) (name_of b)
+end
+module ChildrenS = Set.Make(TreeOrd)
 
 let (^~) (node : Config_tree.t) (node' : Config_tree.t) =
   name_of node = name_of node' &&
@@ -344,3 +352,35 @@ let show_diff ?(cmds=false) path left right =
         diff [] (unified_diff ~cmds:cmds udiff trees) [(Option.some left, Option.some right)];
         if cmds then order_commands udiff;
         !udiff
+
+let union_of_values (n : Config_tree.t) (m : Config_tree.t) =
+    let set_n = ValueS.of_list (data_of n).values in
+    let set_m = ValueS.of_list (data_of m).values in
+    ValueS.elements (ValueS.union set_n set_m)
+
+let union_of_children n m =
+    let set_n = ChildrenS.of_list (children_of n) in
+    let set_m = ChildrenS.of_list (children_of m) in
+    ChildrenS.elements (ChildrenS.union set_n set_m)
+
+(* tree_union is currently used only for unit tests, so only values of data
+   are considered. Should there be a reason to expose it in the future,
+   consistency check and union of remaining data will need to be added.
+ *)
+let rec tree_union s t =
+    let child_of_union s t c =
+        let s_c = Vytree.find s (name_of c) in
+        let t_c = Vytree.find t (name_of c) in
+        match s_c, t_c with
+        | Some child, None -> clone s t [(name_of child)]
+        | None, Some _ -> t
+        | Some u, Some v ->
+                if u ^~ v then
+                    let values = union_of_values u v in
+                    let data = {(data_of v) with Config_tree.values = values} in
+                    Vytree.replace t (Vytree.make data (name_of v))
+                else
+                    Vytree.replace t (tree_union u v)
+        | None, None -> raise Nonexistent_child
+    in
+    List.fold_left (fun x c -> child_of_union s x c) t (union_of_children s t)

--- a/src/config_diff.ml
+++ b/src/config_diff.ml
@@ -133,16 +133,6 @@ let clone ?(recurse=true) ?(set_values=None) old_root new_root path =
             let path_remaining = Vylist.complement path path_existing in
             clone_path ~recurse:recurse ~set_values:set_values old_root new_root path_existing path_remaining
 
-let rec graft_children children stock path =
-    match children with
-    | [] -> stock
-    | x::xs ->
-            let stock = Vytree.insert ~position:Lexical ~children:(children_of x) stock (path @ [name_of x]) (data_of x)
-            in graft_children xs stock path
-
-let graft_tree stem stock path =
-    graft_children (children_of stem) stock path
-
 let is_empty l = (l = [])
 
 (* define the diff_func; in this instance, we imperatively build the difference trees *)
@@ -236,13 +226,10 @@ let compare path left right =
 (* wrapper to return diff trees *)
 let diff_tree path left right =
     let trees = compare path left right in
-    let add_node = Config_tree.make "add" in
-    let sub_node = Config_tree.make "sub" in
-    let int_node = Config_tree.make "inter" in
+    let add_node = make Config_tree.default_data "add" (children_of !(trees.add)) in
+    let sub_node = make Config_tree.default_data "sub" (children_of !(trees.sub)) in
+    let int_node = make Config_tree.default_data "inter" (children_of !(trees.inter)) in
     let ret = make Config_tree.default_data "" [add_node; sub_node; int_node] in
-    let ret = graft_tree !(trees.add) ret ["add"] in
-    let ret = graft_tree !(trees.sub) ret ["sub"] in
-    let ret = graft_tree !(trees.inter) ret ["inter"] in
     ret
 
 (* wrapper to return trimmed tree for 'delete' commands *)

--- a/src/config_diff.mli
+++ b/src/config_diff.mli
@@ -12,6 +12,7 @@ type diff_trees = {
 
 exception Incommensurable
 exception Empty_comparison
+exception Nonexistent_child
 
 val make_diff_trees : Config_tree.t -> Config_tree.t -> diff_trees
 val clone : ?recurse:bool -> ?set_values:(string list) option -> Config_tree.t -> Config_tree.t -> string list -> Config_tree.t
@@ -21,3 +22,4 @@ val compare : string list -> Config_tree.t -> Config_tree.t -> diff_trees
 val diff_tree : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t
 val trim_tree : Config_tree.t -> Config_tree.t -> Config_tree.t
 val show_diff : ?cmds:bool -> string list -> Config_tree.t -> Config_tree.t -> string
+val tree_union : Config_tree.t -> Config_tree.t -> Config_tree.t

--- a/src/config_tree.mli
+++ b/src/config_tree.mli
@@ -38,7 +38,7 @@ val get_subtree : ?with_node:bool -> t -> string list -> t
 
 val render_commands : ?op:command -> t -> string list -> string
 
-val render_config : t -> string
+val render_config : ?ord_val:bool -> t -> string
 
 val render_json : t -> string
 

--- a/src/vylist.ml
+++ b/src/vylist.ml
@@ -28,6 +28,12 @@ let rec insert_after p x xs =
     | y :: ys -> if (p y) then y :: x :: ys
                  else y :: (insert_after p x ys)
 
+let rec insert_compare p x xs =
+    match xs with
+    | [] -> [x]
+    | y :: ys -> if (p x y <= 0) then x :: y :: ys
+                 else y :: (insert_compare p x ys)
+
 let complement xs ys =
     let rec aux xs ys =
         match xs, ys with

--- a/src/vylist.mli
+++ b/src/vylist.mli
@@ -3,5 +3,6 @@ val remove : ('a -> bool) -> 'a list -> 'a list
 val replace : ('a -> bool) -> 'a -> 'a list -> 'a list
 val insert_before : ('a -> bool) -> 'a -> 'a list -> 'a list
 val insert_after : ('a -> bool) -> 'a -> 'a list -> 'a	list
+val insert_compare : ('a -> 'a -> int) -> 'a -> 'a list -> 'a list
 val complement : 'a list -> 'a list -> 'a list
 val in_list : 'a list -> 'a -> bool

--- a/src/vytree.ml
+++ b/src/vytree.ml
@@ -4,7 +4,7 @@ type 'a	t = {
     children: 'a t list
 } [@@deriving yojson]
 
-type position = Before of string | After of string | End | Default
+type position = Before of string | After of string | Lexical | End | Default
 
 exception Empty_path
 exception Duplicate_child
@@ -27,6 +27,8 @@ let insert_immediate ?(position=Default) node name data children =
         | End -> node.children @ [new_node]
         | Before s -> Vylist.insert_before (fun x -> x.name = s) new_node node.children
         | After s -> Vylist.insert_after (fun x -> x.name = s) new_node node.children
+        | Lexical ->
+            Vylist.insert_compare (fun x y -> Util.lexical_numeric_compare x.name y.name) new_node node.children
     in { node with children = children' }
 
 let delete_immediate node name =

--- a/src/vytree.mli
+++ b/src/vytree.mli
@@ -5,7 +5,7 @@ exception Duplicate_child
 exception Nonexistent_path
 exception Insert_error of string
 
-type position = Before of string | After of string | End | Default
+type position = Before of string | After of string | Lexical | End | Default
 
 val make : 'a -> string -> 'a t
 val make_full : 'a -> string -> ('a t) list -> 'a t

--- a/src/vytree.mli
+++ b/src/vytree.mli
@@ -19,6 +19,8 @@ val find_or_fail : 'a t -> string -> 'a t
 
 val adopt : 'a t -> 'a t -> 'a t
 
+val replace : 'a t -> 'a t -> 'a t
+
 val insert : ?position:position -> ?children:('a t list) -> 'a t -> string list -> 'a -> 'a t
 
 val insert_multi_level : 'a -> 'a t -> string list -> string list -> 'a -> 'a t

--- a/src/vytree.mli
+++ b/src/vytree.mli
@@ -25,7 +25,7 @@ val insert : ?position:position -> ?children:('a t list) -> 'a t -> string list 
 
 val insert_multi_level : 'a -> 'a t -> string list -> string list -> 'a -> 'a t
 
-val merge_children : ('a -> 'a -> 'a) -> 'a t -> 'a t
+val merge_children : ('a -> 'a -> 'a) -> (string -> string -> int) -> 'a t -> 'a t
 
 val delete : 'a t -> string list -> 'a t
 
@@ -46,6 +46,8 @@ val exists : 'a t -> string list -> bool
 val children_of_path : 'a t -> string list -> string list
 
 val sorted_children_of_node : (string -> string -> int) -> 'a t -> ('a t) list
+
+val sort_children : (string -> string -> int) -> 'a t -> 'a t
 
 val copy : 'a t -> string list -> string list -> 'a t
 


### PR DESCRIPTION

This adds vyos1x-config support for:
https://vyos.dev/T5087
https://vyos.dev/T5089

It adds a union of configtrees function and minimal enforced ordering of nodes/values as needed to establish identity of objects.
