### PR TITLE
T5194: add support for reference tree

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -6,7 +6,7 @@
 (library
  (name vyos1x)
  (public_name vyos1x-config)
- (libraries yojson menhirLib)
+ (libraries yojson menhirLib fileutils pcre xml-light)
  (preprocess (pps ppx_deriving_yojson))
  (foreign_stubs
   (language c)

--- a/src/generate.ml
+++ b/src/generate.ml
@@ -1,4 +1,7 @@
 (* Load interface definitions from a directory into a reference tree *)
+exception Load_error of string
+exception Write_error of string
+
 let load_interface_definitions dir =
     let open Reference_tree in
     let relative_paths = FileUtil.ls dir in
@@ -14,3 +17,20 @@ let load_interface_definitions dir =
         | Error msg -> Error msg end
     with Bad_interface_definition msg -> Error msg
 
+let reference_tree_to_json from_dir to_file =
+    let ref_tree_result =
+        load_interface_definitions from_dir
+    in
+    let ref_tree =
+    match ref_tree_result with
+        | Ok ref -> ref
+        | Error msg -> raise (Load_error msg)
+    in
+    let out = Reference_tree.render_json ref_tree in
+    let oc =
+        try
+            open_out to_file
+        with Sys_error msg -> raise (Write_error msg)
+    in
+    Printf.fprintf oc "%s" out;
+    close_out oc

--- a/src/generate.ml
+++ b/src/generate.ml
@@ -1,0 +1,16 @@
+(* Load interface definitions from a directory into a reference tree *)
+let load_interface_definitions dir =
+    let open Reference_tree in
+    let relative_paths = FileUtil.ls dir in
+    let absolute_paths =
+        try Ok (List.map Util.absolute_path relative_paths)
+        with Sys_error no_dir_msg -> Error no_dir_msg
+    in
+    let load_aux tree file =
+        load_from_xml tree file
+    in
+    try begin match absolute_paths with
+        | Ok paths  -> Ok (List.fold_left load_aux default paths)
+        | Error msg -> Error msg end
+    with Bad_interface_definition msg -> Error msg
+

--- a/src/generate.mli
+++ b/src/generate.mli
@@ -1,0 +1,1 @@
+val load_interface_definitions : string -> (Reference_tree.t, string) result

--- a/src/generate.mli
+++ b/src/generate.mli
@@ -1,1 +1,5 @@
+exception Load_error of string
+exception Write_error of string
+
 val load_interface_definitions : string -> (Reference_tree.t, string) result
+val reference_tree_to_json : string -> string -> unit

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -161,6 +161,7 @@ let data_from_xml d x =
 
 let rec insert_from_xml basepath reftree xml =
     match xml with
+    | Xml.Element ("syntaxVersion", _, _) -> reftree
     | Xml.Element (_, _,  _) ->
         let props = find_xml_child "properties" xml in
         let data =

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -31,7 +31,6 @@ type ref_node_data = {
     owner: string option;
     priority: string option;
     default_value: string option;
-    keep_order: bool;
     hidden: bool;
     secret: bool;
 } [@@deriving to_yojson]
@@ -54,7 +53,6 @@ let default_data = {
     owner = None;
     priority = None;
     default_value = None;
-    keep_order = false;
     hidden = false;
     secret = false;
 }
@@ -155,7 +153,6 @@ let data_from_xml d x =
             {d with priority=Some i}
         | Xml.Element ("hidden", _, _) -> {d with hidden=true}
         | Xml.Element ("secret", _, _) -> {d with secret=true}
-        | Xml.Element ("keepChildOrder", _, _) -> {d with keep_order=true}
         | _ -> raise (Bad_interface_definition "Malformed property tag")
     in Xml.fold aux d x
 
@@ -233,10 +230,6 @@ let is_leaf reftree path =
 let is_valueless reftree path =
     let data = Vytree.get_data reftree path in
     data.valueless
-
-let get_keep_order reftree path =
-    let data = Vytree.get_data reftree path in
-    data.keep_order
 
 let get_owner reftree path =
     let data = Vytree.get_data reftree path in

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -66,6 +66,17 @@ let load_constraint_from_xml d c =
         | _ -> raise (Bad_interface_definition "Malformed constraint")
     in Xml.fold aux d c
 
+(** Find a child node in xml-lite *)
+let find_xml_child name xml =
+    let find_aux e =
+        match e with
+        | Xml.Element (name', _, _) when name' = name -> true
+        | _ -> false
+    in
+    match xml with
+    | Xml.Element (_, _, children) -> Vylist.find find_aux children
+    | Xml.PCData _ -> None
+
 let data_from_xml d x =
     let aux d x =
         match x with
@@ -90,7 +101,7 @@ let data_from_xml d x =
 let rec insert_from_xml basepath reftree xml =
     match xml with
     | Xml.Element (tag, _,  _) ->
-        let props = Util.find_xml_child "properties" xml in
+        let props = find_xml_child "properties" xml in
         let data =
             (match props with
             | None -> default_data
@@ -107,7 +118,7 @@ let rec insert_from_xml basepath reftree xml =
         (match node_type with
         | Leaf -> new_tree
         | _ ->
-            let children = Util.find_xml_child "children" xml in
+            let children = find_xml_child "children" xml in
             (match children with
              | None -> raise (Bad_interface_definition (Printf.sprintf "Node %s has no children" name))
              | Some c ->  List.fold_left (insert_from_xml path) new_tree (Xml.children c)))

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -1,0 +1,178 @@
+type node_type = Leaf | Tag | Other
+
+type value_constraint =
+    | Regex of string [@name "regex"]
+    | External of string * string option [@name "exec"]
+    [@@deriving yojson]
+
+type ref_node_data = {
+    node_type: node_type;
+    constraints: value_constraint list;
+    help: string;
+    value_help: (string * string) list;
+    constraint_error_message: string;
+    multi: bool;
+    valueless: bool;
+    owner: string option;
+    keep_order: bool;
+    hidden: bool;
+    secret: bool;
+}
+
+type t = ref_node_data Vytree.t
+
+exception Bad_interface_definition of string
+
+exception Validation_error of string
+
+let default_data = {
+    node_type = Other;
+    constraints = [];
+    help = "No help available";
+    value_help = [];
+    constraint_error_message = "Invalid value";
+    multi = false;
+    valueless = false;
+    owner = None;
+    keep_order = false;
+    hidden = false;
+    secret = false;
+}
+
+let default = Vytree.make default_data "root"
+
+(* Loading from XML *)
+
+let node_type_of_string s =
+    match s with
+    | "node" -> Other
+    | "tagNode" -> Tag
+    | "leafNode" -> Leaf
+    | _ -> raise (Bad_interface_definition
+                  (Printf.sprintf "node, tagNode, or leafNode expected, %s found" s))
+
+let load_constraint_from_xml d c =
+    let aux d c =
+        match c with
+        | Xml.Element ("regex", _, [Xml.PCData s]) ->
+            let cs = (Regex s) :: d.constraints in
+            {d with constraints=cs}
+        | Xml.Element ("validator", [("name", n); ("argument", a)], _) ->
+            let cs = (External (n, Some a)) :: d.constraints in
+            {d with constraints=cs}
+        | Xml.Element ("validator", [("name", n)], _) ->
+            let cs = (External (n, None)) :: d.constraints in
+            {d with constraints=cs}
+        | _ -> raise (Bad_interface_definition "Malformed constraint")
+    in Xml.fold aux d c
+
+let data_from_xml d x =
+    let aux d x =
+        match x with
+        | Xml.Element ("help", _, [Xml.PCData s]) -> {d with help=s}
+        | Xml.Element ("valueHelp", _,
+                       [Xml.Element ("format", _, [Xml.PCData fmt]);
+                        Xml.Element ("description", _, [Xml.PCData descr])]) ->
+            let vhs = d.value_help in
+            let vhs' = (fmt, descr) :: vhs in
+            {d with value_help=vhs'}
+        | Xml.Element ("multi", _, _) -> {d with multi=true}
+        | Xml.Element ("valueless", _, _) -> {d with valueless=true}
+        | Xml.Element ("constraintErrorMessage", _, [Xml.PCData s]) ->
+            {d with constraint_error_message=s}
+        | Xml.Element ("constraint", _, _) -> load_constraint_from_xml d x
+        | Xml.Element ("hidden", _, _) -> {d with hidden=true}
+        | Xml.Element ("secret", _, _) -> {d with secret=true}
+        | Xml.Element ("keepChildOrder", _, _) -> {d with keep_order=true}
+        | _ -> raise (Bad_interface_definition "Malformed property tag")
+    in Xml.fold aux d x
+
+let rec insert_from_xml basepath reftree xml =
+    match xml with
+    | Xml.Element (tag, _,  _) ->
+        let props = Util.find_xml_child "properties" xml in
+        let data =
+            (match props with
+            | None -> default_data
+            | Some p -> data_from_xml default_data p)
+        in
+        let node_type = node_type_of_string (Xml.tag xml) in
+        let node_owner = try let o = Xml.attrib xml "owner" in Some o
+                         with _ -> None
+        in
+        let data = {data with node_type=node_type; owner=node_owner} in
+        let name = Xml.attrib xml "name" in
+        let path = basepath @ [name] in
+        let new_tree = Vytree.insert reftree path data in
+        (match node_type with
+        | Leaf -> new_tree
+        | _ ->
+            let children = Util.find_xml_child "children" xml in
+            (match children with
+             | None -> raise (Bad_interface_definition (Printf.sprintf "Node %s has no children" name))
+             | Some c ->  List.fold_left (insert_from_xml path) new_tree (Xml.children c)))
+    | _ -> raise (Bad_interface_definition "PCData not allowed here")
+
+let load_from_xml reftree file =
+    let xml_to_reftree xml reftree =
+        match xml with
+        | Xml.Element ("interfaceDefinition", attrs, children) ->
+            List.fold_left (insert_from_xml []) reftree children
+        | _ -> raise (Bad_interface_definition "Should start with <interfaceDefinition>")
+    in
+    try
+        let xml = Xml.parse_file file in
+        xml_to_reftree xml reftree
+    with
+    | Xml.File_not_found msg -> raise (Bad_interface_definition msg)
+    | Xml.Error e -> raise (Bad_interface_definition (Xml.error e))
+
+let is_multi reftree path =
+    let data = Vytree.get_data reftree path in
+    data.multi
+
+let is_hidden reftree path =
+    let data = Vytree.get_data reftree path in
+    data.hidden
+
+let is_secret reftree path =
+    let data = Vytree.get_data reftree path in
+    data.secret
+
+let is_tag reftree path =
+    let data = Vytree.get_data reftree path in
+    match data.node_type with
+    | Tag -> true
+    | _ -> false
+
+let is_leaf reftree path =
+    let data = Vytree.get_data reftree path in
+    match data.node_type with
+    | Leaf -> true
+    | _ -> false
+
+let is_valueless reftree path =
+    let data = Vytree.get_data reftree path in
+    data.valueless
+
+let get_keep_order reftree path =
+    let data = Vytree.get_data reftree path in
+    data.keep_order
+
+let get_owner reftree path =
+    let data = Vytree.get_data reftree path in
+    data.owner
+
+let get_help_string reftree path =
+    let data = Vytree.get_data reftree path in
+    data.help
+
+let get_value_help reftree path =
+    let data = Vytree.get_data reftree path in
+    data.value_help
+
+let get_completion_data reftree path =
+    let aux node =
+        let data = Vytree.data_of_node node in
+        (data.node_type, data.multi, data.help)
+    in List.map aux (Vytree.children_of_node @@ Vytree.get reftree path)

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -1,8 +1,12 @@
 type node_type =
-    | Leaf  [@name "leaf"]
-    | Tag   [@name "tag"]
-    | Other [@name "other"]
-    [@@deriving yojson]
+    | Leaf
+    | Tag
+    | Other
+
+let node_type_to_yojson = function
+    | Leaf -> `String "leaf"
+    | Tag -> `String "tag"
+    | Other -> `String "other"
 
 type value_constraint =
     | Regex of string [@name "regex"]
@@ -13,7 +17,7 @@ type completion_help_type =
     | List of string [@name "list"]
     | Path of string [@name "path"]
     | Script of string [@name "script"]
-    [@@deriving yojson]
+    [@@deriving to_yojson]
 
 type ref_node_data = {
     node_type: node_type;
@@ -30,9 +34,9 @@ type ref_node_data = {
     keep_order: bool;
     hidden: bool;
     secret: bool;
-} [@@deriving yojson]
+} [@@deriving to_yojson]
 
-type t = ref_node_data Vytree.t [@@deriving yojson]
+type t = ref_node_data Vytree.t [@@deriving to_yojson]
 
 exception Bad_interface_definition of string
 

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -14,6 +14,7 @@ type ref_node_data = {
     multi: bool;
     valueless: bool;
     owner: string option;
+    priority: string option;
     keep_order: bool;
     hidden: bool;
     secret: bool;
@@ -34,6 +35,7 @@ let default_data = {
     multi = false;
     valueless = false;
     owner = None;
+    priority = None;
     keep_order = false;
     hidden = false;
     secret = false;
@@ -92,6 +94,8 @@ let data_from_xml d x =
         | Xml.Element ("constraintErrorMessage", _, [Xml.PCData s]) ->
             {d with constraint_error_message=s}
         | Xml.Element ("constraint", _, _) -> load_constraint_from_xml d x
+        | Xml.Element ("priority", _, [Xml.PCData i]) ->
+            {d with priority=Some i}
         | Xml.Element ("hidden", _, _) -> {d with hidden=true}
         | Xml.Element ("secret", _, _) -> {d with secret=true}
         | Xml.Element ("keepChildOrder", _, _) -> {d with keep_order=true}

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -100,7 +100,7 @@ let data_from_xml d x =
 
 let rec insert_from_xml basepath reftree xml =
     match xml with
-    | Xml.Element (tag, _,  _) ->
+    | Xml.Element (_, _,  _) ->
         let props = find_xml_child "properties" xml in
         let data =
             (match props with
@@ -127,7 +127,7 @@ let rec insert_from_xml basepath reftree xml =
 let load_from_xml reftree file =
     let xml_to_reftree xml reftree =
         match xml with
-        | Xml.Element ("interfaceDefinition", attrs, children) ->
+        | Xml.Element ("interfaceDefinition", _, children) ->
             List.fold_left (insert_from_xml []) reftree children
         | _ -> raise (Bad_interface_definition "Should start with <interfaceDefinition>")
     in

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -39,7 +39,7 @@ let default_data = {
     secret = false;
 }
 
-let default = Vytree.make default_data "root"
+let default = Vytree.make default_data ""
 
 (* Loading from XML *)
 

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -26,6 +26,7 @@ type ref_node_data = {
     valueless: bool;
     owner: string option;
     priority: string option;
+    default_value: string option;
     keep_order: bool;
     hidden: bool;
     secret: bool;
@@ -48,6 +49,7 @@ let default_data = {
     valueless = false;
     owner = None;
     priority = None;
+    default_value = None;
     keep_order = false;
     hidden = false;
     secret = false;
@@ -166,7 +168,13 @@ let rec insert_from_xml basepath reftree xml =
         let node_owner = try let o = Xml.attrib xml "owner" in Some o
                          with _ -> None
         in
-        let data = {data with node_type=node_type; owner=node_owner} in
+        let default_value_elem = find_xml_child "defaultValue" xml in
+        let default_value =
+            (match default_value_elem with
+            | Some (Xml.Element (_, _, [Xml.PCData s])) -> Some s
+            | _ -> None)
+        in
+        let data = {data with node_type=node_type; owner=node_owner; default_value=default_value} in
         let name = Xml.attrib xml "name" in
         let path = basepath @ [name] in
         let new_tree = Vytree.insert_maybe reftree path data in

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -118,7 +118,7 @@ let rec insert_from_xml basepath reftree xml =
         let data = {data with node_type=node_type; owner=node_owner} in
         let name = Xml.attrib xml "name" in
         let path = basepath @ [name] in
-        let new_tree = Vytree.insert reftree path data in
+        let new_tree = Vytree.insert_maybe reftree path data in
         (match node_type with
         | Leaf -> new_tree
         | _ ->

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -26,7 +26,6 @@ type ref_node_data = {
     owner: string option;
     priority: string option;
     default_value: string option;
-    keep_order: bool;
     hidden: bool;
     secret: bool;
 } [@@deriving to_yojson]
@@ -54,8 +53,6 @@ val is_tag : t -> string list -> bool
 val is_leaf : t -> string list -> bool
 
 val is_valueless : t -> string list -> bool
-
-val get_keep_order : t -> string list -> bool
 
 val get_owner : t -> string list -> string option
 

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -9,12 +9,19 @@ type value_constraint =
     | External of string * string option [@name "exec"]
     [@@deriving yojson]
 
+type completion_help_type =
+    | List of string [@name "list"]
+    | Path of string [@name "path"]
+    | Script of string [@name "script"]
+    [@@deriving yojson]
+
 type ref_node_data = {
     node_type: node_type;
     constraints: value_constraint list;
+    constraint_error_message: string;
+    completion_help: completion_help_type list;
     help: string;
     value_help: (string * string) list;
-    constraint_error_message: string;
     multi: bool;
     valueless: bool;
     owner: string option;

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -26,6 +26,7 @@ type ref_node_data = {
     valueless: bool;
     owner: string option;
     priority: string option;
+    default_value: string option;
     keep_order: bool;
     hidden: bool;
     secret: bool;

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -1,0 +1,54 @@
+type node_type = Leaf | Tag | Other
+
+type value_constraint =
+    | Regex of string [@name "regex"]
+    | External of string * string option [@name "exec"]
+    [@@deriving yojson]
+
+type ref_node_data = {
+    node_type: node_type;
+    constraints: value_constraint list;
+    help: string;
+    value_help: (string * string) list;
+    constraint_error_message: string;
+    multi: bool;
+    valueless: bool;
+    owner: string option;
+    keep_order: bool;
+    hidden: bool;
+    secret: bool;
+}
+
+exception Bad_interface_definition of string
+
+exception Validation_error of string
+
+type t = ref_node_data Vytree.t
+
+val default_data : ref_node_data
+
+val default : t
+
+val load_from_xml : t -> string -> t
+
+val is_multi : t -> string list -> bool
+
+val is_hidden : t -> string list -> bool
+
+val is_secret : t -> string list -> bool
+
+val is_tag : t -> string list -> bool
+
+val is_leaf : t -> string list -> bool
+
+val is_valueless : t -> string list -> bool
+
+val get_keep_order : t -> string list -> bool
+
+val get_owner : t -> string list -> string option
+
+val get_help_string : t -> string list -> string
+
+val get_value_help : t -> string list -> (string * string) list
+
+val get_completion_data : t -> string list -> (node_type * bool * string) list

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -1,8 +1,7 @@
 type node_type =
-    | Leaf  [@name "leaf"]
-    | Tag   [@name "tag"]
-    | Other [@name "other"]
-    [@@deriving yojson]
+    | Leaf
+    | Tag
+    | Other
 
 type value_constraint =
     | Regex of string [@name "regex"]
@@ -13,7 +12,7 @@ type completion_help_type =
     | List of string [@name "list"]
     | Path of string [@name "path"]
     | Script of string [@name "script"]
-    [@@deriving yojson]
+    [@@deriving to_yojson]
 
 type ref_node_data = {
     node_type: node_type;
@@ -30,9 +29,9 @@ type ref_node_data = {
     keep_order: bool;
     hidden: bool;
     secret: bool;
-} [@@deriving yojson]
+} [@@deriving to_yojson]
 
-type t = ref_node_data Vytree.t [@@deriving yojson]
+type t = ref_node_data Vytree.t [@@deriving to_yojson]
 
 exception Bad_interface_definition of string
 

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -1,4 +1,8 @@
-type node_type = Leaf | Tag | Other
+type node_type =
+    | Leaf  [@name "leaf"]
+    | Tag   [@name "tag"]
+    | Other [@name "other"]
+    [@@deriving yojson]
 
 type value_constraint =
     | Regex of string [@name "regex"]
@@ -18,13 +22,13 @@ type ref_node_data = {
     keep_order: bool;
     hidden: bool;
     secret: bool;
-}
+} [@@deriving yojson]
+
+type t = ref_node_data Vytree.t [@@deriving yojson]
 
 exception Bad_interface_definition of string
 
 exception Validation_error of string
-
-type t = ref_node_data Vytree.t
 
 val default_data : ref_node_data
 
@@ -53,3 +57,5 @@ val get_help_string : t -> string list -> string
 val get_value_help : t -> string list -> (string * string) list
 
 val get_completion_data : t -> string list -> (node_type * bool * string) list
+
+val render_json : t -> string

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -14,6 +14,7 @@ type ref_node_data = {
     multi: bool;
     valueless: bool;
     owner: string option;
+    priority: string option;
     keep_order: bool;
     hidden: bool;
     secret: bool;

--- a/src/util.ml
+++ b/src/util.ml
@@ -34,3 +34,7 @@ let default default_value opt =
 
 let lexical_numeric_compare s t =
     lex_numeric_compare s t
+
+(** Convert a relative path to an absolute path based on the current working directory *)
+let absolute_path relative_path =
+    FilePath.make_absolute (Sys.getcwd ()) relative_path

--- a/src/util.mli
+++ b/src/util.mli
@@ -7,3 +7,5 @@ val escape_string : string -> string
 val default : 'a -> 'a option -> 'a
 
 val lexical_numeric_compare : string -> string -> int
+
+val absolute_path : FilePath.filename -> FilePath.filename

--- a/src/vytree.ml
+++ b/src/vytree.ml
@@ -88,6 +88,10 @@ let rec insert ?(position=Default) ?(children=[]) node path data =
             let s = Printf.sprintf "Non-existent intermediary node: \'%s\'" name in
             raise (Insert_error s)
 
+let insert_maybe ?(position=Default) node path data =
+    try insert ~position:position node path data
+    with Duplicate_child -> node
+
 let sorted_children_of_node cmp node =
     let names = list_children node in
     let names = List.sort cmp names in

--- a/src/vytree.mli
+++ b/src/vytree.mli
@@ -23,6 +23,8 @@ val replace : 'a t -> 'a t -> 'a t
 
 val insert : ?position:position -> ?children:('a t list) -> 'a t -> string list -> 'a -> 'a t
 
+val insert_maybe : ?position:position -> 'a t -> string list -> 'a -> 'a t
+
 val insert_multi_level : 'a -> 'a t -> string list -> string list -> 'a -> 'a t
 
 val merge_children : ('a -> 'a -> 'a) -> (string -> string -> int) -> 'a t -> 'a t


### PR DESCRIPTION
Add support for reference tree loading from XML interfaces definitions, and rendering to JSON. The value_checker is dropped for now, as the initial goal is to provide node context information to (1; implemented in PR pending) vyos-1x for the XML query lib (is_multi, is_tag, is_tag_value, default_values, ...) and optionally (2; not yet implemented) as a JSON file to be queried by configtree using jsonm or similar.

N.B.  this will require the opam package xml-light to be added to the Docker image, as a build dependency.