### PR TITLE
T5194: filter on files of extension .xml

### DIFF
--- a/src/generate.ml
+++ b/src/generate.ml
@@ -4,7 +4,10 @@ exception Write_error of string
 
 let load_interface_definitions dir =
     let open Reference_tree in
-    let relative_paths = FileUtil.ls dir in
+    let dir_paths = FileUtil.ls dir in
+    let relative_paths =
+      List.filter (fun x -> Filename.extension x = ".xml") dir_paths
+    in
     let absolute_paths =
         try Ok (List.map Util.absolute_path relative_paths)
         with Sys_error no_dir_msg -> Error no_dir_msg


### PR DESCRIPTION
Restrict function reference_tree_to_json to files of extension .xml. For vyos-1x this is not necessary, as a build dir is prepared consisting solely of 'transcluded' interface-definitions. However, other uses may call the function on a directory with subdirs, hidden files, or remnants of the transcluding-in-place. We thus presume that the only interesting files have extension .xml, which seems a reasonable constraint.