### PR TITLE
T6149: update node_data if necessary when merging nodes

### DIFF
--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -179,7 +179,12 @@ let rec insert_from_xml basepath reftree xml =
         let data = {data with node_type=node_type; owner=node_owner; default_value=default_value} in
         let name = Xml.attrib xml "name" in
         let path = basepath @ [name] in
-        let new_tree = Vytree.insert_maybe reftree path data in
+        let new_tree =
+            if data <> default_data then
+                Vytree.insert_or_update reftree path data
+            else
+                Vytree.insert_maybe reftree path data
+        in
         (match node_type with
         | Leaf -> new_tree
         | _ ->

--- a/src/vytree.ml
+++ b/src/vytree.ml
@@ -167,6 +167,10 @@ let update node path data =
         replace node' child
     in do_with_child (update_data data) node path
 
+let insert_or_update ?(position=Default) node path data =
+    try insert ~position:position node path data
+    with Duplicate_child -> update node path data
+
 let rec get node path =
     match path with
     | [] -> raise Empty_path

--- a/src/vytree.mli
+++ b/src/vytree.mli
@@ -25,6 +25,8 @@ val insert : ?position:position -> ?children:('a t list) -> 'a t -> string list 
 
 val insert_maybe : ?position:position -> 'a t -> string list -> 'a -> 'a t
 
+val insert_or_update : ?position:position -> 'a t -> string list -> 'a -> 'a t
+
 val insert_multi_level : 'a -> 'a t -> string list -> string list -> 'a -> 'a t
 
 val merge_children : ('a -> 'a -> 'a) -> (string -> string -> int) -> 'a t -> 'a t


### PR DESCRIPTION
Upon making use of owner/priority data for nodes, it became apparent that node_data was not updated when adding redundant nodes from XML interface_definitions.