### PR TITLE
T6180: add ability to apply mask to config tree

### DIFF
--- a/src/config_diff.mli
+++ b/src/config_diff.mli
@@ -37,3 +37,4 @@ exception Nonexistent_child
 val diff_tree : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t
 val show_diff : ?cmds:bool -> string list -> Config_tree.t -> Config_tree.t -> string
 val tree_union : Config_tree.t -> Config_tree.t -> Config_tree.t
+val mask_tree : Config_tree.t -> Config_tree.t -> Config_tree.t


### PR DESCRIPTION
Add function `mask_tree(config, mask)` to return subtree containing only full paths of mask: useful for config-sync to mask off the subset of config that should be synchronized.

Companion PR:
https://github.com/vyos/libvyosconfig/pull/13