### PR TITLE
 T6149: T6180: combined backports for reference_tree bug resp. mask_tree function

### DIFF
--- a/src/config_diff.mli
+++ b/src/config_diff.mli
@@ -37,3 +37,4 @@ exception Nonexistent_child
 val diff_tree : string list -> Config_tree.t -> Config_tree.t -> Config_tree.t
 val show_diff : ?cmds:bool -> string list -> Config_tree.t -> Config_tree.t -> string
 val tree_union : Config_tree.t -> Config_tree.t -> Config_tree.t
+val mask_tree : Config_tree.t -> Config_tree.t -> Config_tree.t

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -179,7 +179,12 @@ let rec insert_from_xml basepath reftree xml =
         let data = {data with node_type=node_type; owner=node_owner; default_value=default_value} in
         let name = Xml.attrib xml "name" in
         let path = basepath @ [name] in
-        let new_tree = Vytree.insert_maybe reftree path data in
+        let new_tree =
+            if data <> default_data then
+                Vytree.insert_or_update reftree path data
+            else
+                Vytree.insert_maybe reftree path data
+        in
         (match node_type with
         | Leaf -> new_tree
         | _ ->

--- a/src/vytree.ml
+++ b/src/vytree.ml
@@ -167,6 +167,10 @@ let update node path data =
         replace node' child
     in do_with_child (update_data data) node path
 
+let insert_or_update ?(position=Default) node path data =
+    try insert ~position:position node path data
+    with Duplicate_child -> update node path data
+
 let rec get node path =
     match path with
     | [] -> raise Empty_path

--- a/src/vytree.mli
+++ b/src/vytree.mli
@@ -25,6 +25,8 @@ val insert : ?position:position -> ?children:('a t list) -> 'a t -> string list 
 
 val insert_maybe : ?position:position -> 'a t -> string list -> 'a -> 'a t
 
+val insert_or_update : ?position:position -> 'a t -> string list -> 'a -> 'a t
+
 val insert_multi_level : 'a -> 'a t -> string list -> string list -> 'a -> 'a t
 
 val merge_children : ('a -> 'a -> 'a) -> (string -> string -> int) -> 'a t -> 'a t


### PR DESCRIPTION
As discussed, we want to backport support for config-sync: add the mask_tree function and an earlier bug fix (to allow the priority.py rewrite and doc generator); this brings sagitta up to date with current.