### PR TITLE
vyconf: T5083: add childRequirement to reference tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _build/*
 
 *.merlin
 *.install
+
+test/testresults/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+SHELL := bash
+.ONESHELL:
+.SHELLFLAGS := -xeu -o pipefail -c # Enable output of every command as they are ran
+.DELETE_ON_ERROR:
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+MAKEDIR := $(CURDIR)
+
+default: deps deps-lock test build
+
+.PHONY: deps
+deps: vyos1x-config.opam
+	@opam install -y . --deps-only
+
+.PHONY:build
+build: deps
+	@dune build
+
+.PHONY: deps-lock
+deps-lock: deps
+	@opam lock .
+
+.PHONY: test-prep
+test-prep: clean
+	@opam install -y .
+	dune build ./test/
+
+.PHONY: test
+test: test-prep
+	@cd _build/default/test/
+	dune exec ./test_vyos1x.bc
+	cd $(MAKEDIR)
+
+.PHONY: clean
+clean:
+	@dune clean
+	rm -rf test/testresults

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -8,6 +8,13 @@ type value_constraint =
     | External of string * string option [@name "exec"]
     [@@deriving yojson]
 
+type child_requirements_type = 
+    | Require of string list [@name "require"]
+    | Conflict of (string * string) [@name "conflict"]
+    | AtLeastOneOf of string list [@name "atLeastOneOf"]
+    | Depend of (string * string) [@name "depend"]
+    [@@deriving to_yojson]
+
 type completion_help_type =
     | List of string [@name "list"]
     | Path of string [@name "path"]
@@ -19,6 +26,7 @@ type ref_node_data = {
     constraints: value_constraint list;
     constraint_group: value_constraint list;
     constraint_error_message: string;
+    child_requirements: child_requirements_type list;
     completion_help: completion_help_type list;
     help: string;
     value_help: (string * string) list;

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_vyos1x)
+ (libraries vyos1x alcotest)
+ (modes byte exe))

--- a/test/test_vyos1x.ml
+++ b/test/test_vyos1x.ml
@@ -1,0 +1,23 @@
+let create_newdir path perm =
+  if not (Sys.file_exists path) then Sys.mkdir path perm
+
+let test_example name () =
+  let greeting = "Hello " ^ name ^ "!" in
+  let expected = Printf.sprintf "Hello %s!" name in
+  Alcotest.check Alcotest.string "same string" greeting expected
+
+
+
+let test_reference_tree_to_json from_dir to_file () =
+  let _ = print_endline (Sys.getcwd()) in
+  let _ = create_newdir "../../../test/testresults" 0o777 in
+  Vyos1x.Generate.reference_tree_to_json from_dir to_file
+
+let interfaceDefinitionSuite =
+  [ 
+    "can greet Tom", `Quick, test_example "Tom";
+    "Generate xml to json cache", `Quick, test_reference_tree_to_json "../../../test/testdata/interface-definitions" "../../../test/testresults/xml_cache.json";
+  ]
+
+let () =
+  Alcotest.run "Test Suite" [ "InterfaceDefinitions", interfaceDefinitionSuite ]

--- a/test/testdata/interface-definitions/container.xml
+++ b/test/testdata/interface-definitions/container.xml
@@ -1,0 +1,638 @@
+<interfaceDefinition>
+  <node name="container" owner="${vyos_conf_scripts_dir}/container.py">
+    <properties>
+      <help>Container applications</help>
+      <priority>450</priority>
+    </properties>
+    <children>
+      <tagNode name="name">
+        <properties>
+          <help>Container name</help>
+          <constraint>
+            <regex>[-a-zA-Z0-9]+</regex>
+          </constraint>
+          <constraintErrorMessage>Container name must be alphanumeric and can contain hyphens</constraintErrorMessage>
+          <childRequirements>
+            <require>
+              <child name="image"/>
+              <child name="test"/>
+            </require>
+            <conflict name="allow_host_networks">
+              <child name="network"/>
+              <child name="test2"/>
+            </conflict>
+            <conflict name="introvert">
+              <child name="extrovert"/>
+              <child name="influencer"/>
+            </conflict>
+            <atLeastOneOf>
+              <child name="allow_host_networks"/>
+              <child name="network"/>
+            </atLeastOneOf>
+            <depend name="gid">
+              <child name="uid"/>
+              <child name="test3"/>
+            </depend>
+          </childRequirements>
+        </properties>
+        <children>
+          <leafNode name="allow-host-networks">
+            <properties>
+              <help>Allow host networks in container</help>
+              <valueless/>
+            </properties>
+          </leafNode>
+          <leafNode name="capability">
+            <properties>
+              <help>Grant individual Linux capability to container instance</help>
+              <completionHelp>
+                <list>net-admin net-bind-service net-raw setpcap sys-admin sys-module sys-nice sys-time</list>
+              </completionHelp>
+              <valueHelp>
+                <format>net-admin</format>
+                <description>Network operations (interface, firewall, routing tables)</description>
+              </valueHelp>
+              <valueHelp>
+                <format>net-bind-service</format>
+                <description>Bind a socket to privileged ports (port numbers less than 1024)</description>
+              </valueHelp>
+              <valueHelp>
+                <format>net-raw</format>
+                <description>Permission to create raw network sockets</description>
+              </valueHelp>
+              <valueHelp>
+                <format>setpcap</format>
+                <description>Capability sets (from bounded or inherited set)</description>
+              </valueHelp>
+              <valueHelp>
+                <format>sys-admin</format>
+                <description>Administation operations (quotactl, mount, sethostname, setdomainame)</description>
+              </valueHelp>
+              <valueHelp>
+                <format>sys-module</format>
+                <description>Load, unload and delete kernel modules</description>
+              </valueHelp>
+              <valueHelp>
+                <format>sys-nice</format>
+                <description>Permission to set process nice value</description>
+              </valueHelp>
+              <valueHelp>
+                <format>sys-time</format>
+                <description>Permission to set system clock</description>
+              </valueHelp>
+              <constraint>
+                <regex>(net-admin|net-bind-service|net-raw|setpcap|sys-admin|sys-module|sys-nice|sys-time)</regex>
+              </constraint>
+              <multi/>
+            </properties>
+          </leafNode>
+<!-- include start from generic-description.xml.i -->
+<leafNode name="description">
+  <properties>
+    <help>Description</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Description</description>
+    </valueHelp>
+    <constraint>
+      <regex>.{0,255}</regex>
+    </constraint>
+    <constraintErrorMessage>Description too long (limit 255 characters)</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->
+          <tagNode name="device">
+            <properties>
+              <help>Add a host device to the container</help>
+            </properties>
+            <children>
+              <leafNode name="source">
+                <properties>
+                  <help>Source device (Example: "/dev/x")</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Source device</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="destination">
+                <properties>
+                  <help>Destination container device (Example: "/dev/x")</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Destination container device</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+<!-- include start from generic-disable-node.xml.i -->
+<leafNode name="disable">
+  <properties>
+    <help>Disable instance</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->
+          <tagNode name="environment">
+            <properties>
+              <help>Add custom environment variables</help>
+              <constraint>
+                <regex>[-_a-zA-Z0-9]+</regex>
+              </constraint>
+              <constraintErrorMessage>Environment variable name must be alphanumeric and can contain hyphen and underscores</constraintErrorMessage>
+            </properties>
+            <children>
+              <leafNode name="value">
+                <properties>
+                  <help>Set environment option value</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Set environment option value</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+          <leafNode name="entrypoint">
+            <properties>
+              <help>Override the default ENTRYPOINT from the image</help>
+              <constraint>
+                <regex>[ !#-%&amp;(-~]+</regex>
+              </constraint>
+              <constraintErrorMessage>Entrypoint must be ASCII characters, use &amp;quot; and &amp;apos for double and single quotes respectively</constraintErrorMessage>
+            </properties>
+          </leafNode>
+          <leafNode name="host-name">
+            <properties>
+              <help>Container host name</help>
+              <constraint>
+<!-- include start from constraint/host-name.xml.i -->
+<regex>[A-Za-z0-9][-.A-Za-z0-9]*[A-Za-z0-9]</regex>
+<!-- include end -->
+              </constraint>
+              <constraintErrorMessage>Host-name must be alphanumeric and can contain hyphens</constraintErrorMessage>
+            </properties>
+          </leafNode>
+          <leafNode name="image">
+            <properties>
+              <help>Container image to use</help>
+              <completionHelp>
+                <script>sudo podman image list --format "{{.Repository}}:{{.Tag}}"</script>
+              </completionHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Image name in the hub-registry</description>
+              </valueHelp>
+              <constraint>
+                <regex>[[:ascii:]]{1,255}</regex>
+              </constraint>
+            </properties>
+          </leafNode>
+          <leafNode name="command">
+            <properties>
+              <help>Override the default CMD from the image</help>
+              <constraint>
+                <regex>[ !#-%&amp;(-~]+</regex>
+              </constraint>
+              <constraintErrorMessage>Command must be ASCII characters, use &amp;quot; and &amp;apos for double and single quotes respectively</constraintErrorMessage>
+            </properties>
+          </leafNode>
+          <leafNode name="arguments">
+            <properties>
+              <help>The command's arguments for this container</help>
+              <constraint>
+                <regex>[ !#-%&amp;(-~]+</regex>
+              </constraint>
+              <constraintErrorMessage>The command's arguments must be ASCII characters, use &amp;quot; and &amp;apos for double and single quotes respectively</constraintErrorMessage>
+            </properties>
+          </leafNode>
+          <tagNode name="label">
+            <properties>
+              <help>Add label variables</help>
+              <constraint>
+                <regex>[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?</regex>
+              </constraint>
+              <constraintErrorMessage>Label variable name must be alphanumeric and can contain hyphen, dots and underscores</constraintErrorMessage>
+            </properties>
+            <children>
+              <leafNode name="value">
+                <properties>
+                  <help>Set label option value</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Set label option value</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>[[:ascii:]]{1,255}</regex>
+                  </constraint>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+          <leafNode name="memory">
+            <properties>
+              <help>Memory (RAM) available to this container</help>
+              <valueHelp>
+                <format>u32:0</format>
+                <description>Unlimited</description>
+              </valueHelp>
+              <valueHelp>
+                <format>u32:1-16384</format>
+                <description>Container memory in megabytes (MB)</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 0-16384"/>
+              </constraint>
+              <constraintErrorMessage>Container memory must be in range 0 to 16384 MB</constraintErrorMessage>
+            </properties>
+            <defaultValue>512</defaultValue>
+          </leafNode>
+          <leafNode name="shared-memory">
+            <properties>
+              <help>Shared memory available to this container</help>
+              <valueHelp>
+                <format>u32:0</format>
+                <description>Unlimited</description>
+              </valueHelp>
+              <valueHelp>
+                <format>u32:1-8192</format>
+                <description>Container memory in megabytes (MB)</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 0-8192"/>
+              </constraint>
+              <constraintErrorMessage>Container memory must be in range 0 to 8192 MB</constraintErrorMessage>
+            </properties>
+            <defaultValue>64</defaultValue>
+          </leafNode>
+          <tagNode name="network">
+            <properties>
+              <help>Attach user defined network to container</help>
+              <completionHelp>
+                <path>container network</path>
+              </completionHelp>
+<!-- include start from constraint/container-network.xml.i -->
+<constraint>
+  <regex>[-_a-zA-Z0-9]{1,11}</regex>
+</constraint>
+<constraintErrorMessage>Network name cannot be longer than 11 characters</constraintErrorMessage>
+<!-- include end -->
+            </properties>
+            <children>
+              <leafNode name="address">
+                <properties>
+                  <help>Assign static IP address to container</help>
+                  <valueHelp>
+                    <format>ipv4</format>
+                    <description>IPv4 address</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6</format>
+                    <description>IPv6 address</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ip-address"/>
+                  </constraint>
+                  <multi/>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+          <tagNode name="port">
+            <properties>
+              <help>Publish port to the container</help>
+            </properties>
+            <children>
+<!-- include start from listen-address.xml.i -->
+<leafNode name="listen-address">
+  <properties>
+    <help>Local IP addresses to listen on</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_local_ips.sh --both</script>
+    </completionHelp>
+    <valueHelp>
+      <format>ipv4</format>
+      <description>IPv4 address to listen for incoming connections</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6</format>
+      <description>IPv6 address to listen for incoming connections</description>
+    </valueHelp>
+    <multi/>
+    <constraint>
+      <validator name="ip-address"/>
+      <validator name="ipv6-link-local"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->
+              <leafNode name="source">
+                <properties>
+                  <help>Source host port</help>
+                  <valueHelp>
+                    <format>u32:1-65535</format>
+                    <description>Source host port</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>start-end</format>
+                    <description>Source host port range (e.g. 10025-10030)</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="port-range"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="destination">
+                <properties>
+                  <help>Destination container port</help>
+                  <valueHelp>
+                    <format>u32:1-65535</format>
+                    <description>Destination container port</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>start-end</format>
+                    <description>Destination container port range (e.g. 10025-10030)</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="port-range"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="protocol">
+                <properties>
+                  <help>Transport protocol used for port mapping</help>
+                  <completionHelp>
+                    <list>tcp udp</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>tcp</format>
+                    <description>Use Transmission Control Protocol for given port</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>udp</format>
+                    <description>Use User Datagram Protocol for given port</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(tcp|udp)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>tcp</defaultValue>
+              </leafNode>
+            </children>
+          </tagNode>
+          <leafNode name="restart">
+            <properties>
+              <help>Restart options for container</help>
+              <completionHelp>
+                <list>no on-failure always</list>
+              </completionHelp>
+              <valueHelp>
+                <format>no</format>
+                <description>Do not restart containers on exit</description>
+              </valueHelp>
+              <valueHelp>
+                <format>on-failure</format>
+                <description>Restart containers when they exit with a non-zero exit code, retrying indefinitely</description>
+              </valueHelp>
+              <valueHelp>
+                <format>always</format>
+                <description>Restart containers when they exit, regardless of status, retrying indefinitely</description>
+              </valueHelp>
+              <constraint>
+                <regex>(no|on-failure|always)</regex>
+              </constraint>
+            </properties>
+            <defaultValue>on-failure</defaultValue>
+          </leafNode>
+          <leafNode name="uid">
+            <properties>
+              <help>User ID this container will run as</help>
+              <valueHelp>
+                <format>u32:0-65535</format>
+                <description>User ID this container will run as</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 0-65535"/>
+              </constraint>
+            </properties>
+          </leafNode>
+          <leafNode name="gid">
+            <properties>
+              <help>Group ID this container will run as</help>
+              <valueHelp>
+                <format>u32:0-65535</format>
+                <description>Group ID this container will run as</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 0-65535"/>
+              </constraint>
+            </properties>
+          </leafNode>
+          <tagNode name="volume">
+            <properties>
+              <help>Mount a volume into the container</help>
+            </properties>
+            <children>
+              <leafNode name="source">
+                <properties>
+                  <help>Source host directory</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Source host directory</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="destination">
+                <properties>
+                  <help>Destination container directory</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Destination container directory</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="mode">
+                <properties>
+                  <help>Volume access mode ro/rw</help>
+                  <completionHelp>
+                    <list>ro rw</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>ro</format>
+                    <description>Volume mounted into the container as read-only</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>rw</format>
+                    <description>Volume mounted into the container as read-write</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(ro|rw)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>rw</defaultValue>
+              </leafNode>
+              <leafNode name="propagation">
+                <properties>
+                  <help>Volume bind propagation</help>
+                  <completionHelp>
+                    <list>shared slave private rshared rslave rprivate</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>shared</format>
+                    <description>Sub-mounts of the original mount are exposed to replica mounts</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>slave</format>
+                    <description>Allow replica mount to see sub-mount from the original mount but not vice versa</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>private</format>
+                    <description>Sub-mounts within a mount are not visible to replica mounts or the original mount</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>rshared</format>
+                    <description>Allows sharing of mount points and their nested mount points between both the original and replica mounts</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>rslave</format>
+                    <description>Allows mount point and their nested mount points between original an replica mounts</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>rprivate</format>
+                    <description>No mount points within original or replica mounts in any direction</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(shared|slave|private|rshared|rslave|rprivate)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>rprivate</defaultValue>
+              </leafNode>
+            </children>
+          </tagNode>
+        </children>
+      </tagNode>
+      <tagNode name="network">
+        <properties>
+          <help>Network name</help>
+<!-- include start from constraint/container-network.xml.i -->
+<constraint>
+  <regex>[-_a-zA-Z0-9]{1,11}</regex>
+</constraint>
+<constraintErrorMessage>Network name cannot be longer than 11 characters</constraintErrorMessage>
+<!-- include end -->
+        </properties>
+        <children>
+<!-- include start from generic-description.xml.i -->
+<leafNode name="description">
+  <properties>
+    <help>Description</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Description</description>
+    </valueHelp>
+    <constraint>
+      <regex>.{0,255}</regex>
+    </constraint>
+    <constraintErrorMessage>Description too long (limit 255 characters)</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->
+          <leafNode name="prefix">
+            <properties>
+              <help>Prefix which allocated to that network</help>
+              <valueHelp>
+                <format>ipv4net</format>
+                <description>IPv4 network prefix</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ipv6net</format>
+                <description>IPv6 network prefix</description>
+              </valueHelp>
+              <constraint>
+                <validator name="ipv4-prefix"/>
+                <validator name="ipv6-prefix"/>
+              </constraint>
+              <multi/>
+            </properties>
+          </leafNode>
+<!-- include start from interface/vrf.xml.i -->
+<leafNode name="vrf">
+  <properties>
+    <help>VRF instance name</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>VRF instance name</description>
+    </valueHelp>
+    <completionHelp>
+      <path>vrf name</path>
+    </completionHelp>
+<!-- include start from constraint/vrf.xml.i -->
+<constraint>
+  <validator name="vrf-name"/>
+</constraint>
+<constraintErrorMessage>VRF instance name must be 15 characters or less and can not\nbe named as regular network interfaces.\nA name must starts from a letter.\n</constraintErrorMessage>
+<!-- include end -->
+  </properties>
+</leafNode>
+<!-- include end -->
+        </children>
+      </tagNode>
+      <tagNode name="registry">
+        <properties>
+          <help>Registry Name</help>
+        </properties>
+        <defaultValue>docker.io quay.io</defaultValue>
+        <children>
+<!-- include start from interface/authentication.xml.i -->
+<node name="authentication">
+  <properties>
+    <help>Authentication settings</help>
+  </properties>
+  <children>
+<!-- include start from generic-username.xml.i -->
+<leafNode name="username">
+  <properties>
+    <help>Username used for authentication</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Username</description>
+    </valueHelp>
+    <constraint>
+      <regex>[[:ascii:]]{1,128}</regex>
+    </constraint>
+    <constraintErrorMessage>Username is limited to ASCII characters only, with a total length of 128</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->
+<!-- include start from generic-password.xml.i -->
+<leafNode name="password">
+  <properties>
+    <help>Password used for authentication</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Password</description>
+    </valueHelp>
+    <constraint>
+      <regex>[[:ascii:]]{1,128}</regex>
+    </constraint>
+    <constraintErrorMessage>Password is limited to ASCII characters only, with a total length of 128</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->
+  </children>
+</node>
+<!-- include end -->
+<!-- include start from generic-disable-node.xml.i -->
+<leafNode name="disable">
+  <properties>
+    <help>Disable instance</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->
+        </children>
+      </tagNode>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/vyos1x-config.opam
+++ b/vyos1x-config.opam
@@ -21,4 +21,7 @@ depends: [
   "dune" {build & >= "1.4.0"}
   "ppx_deriving_yojson"
   "yojson"
+  "xml-light"
+  "pcre"
+  "fileutils"
 ]

--- a/vyos1x-config.opam.locked
+++ b/vyos1x-config.opam.locked
@@ -1,0 +1,97 @@
+opam-version: "2.0"
+name: "vyos1x-config"
+version: "0.2"
+synopsis: "VyOS 1.x and EdgeOS config file manipulation library"
+description:
+  "A library for parsing, manipulating, and exporting VyOS 1.x and EdgeOS config files."
+maintainer: "Daniil Baturin <daniil@baturin.org>"
+authors: "VyOS maintainers and contributors <maintainers@vyos.net>"
+license: "MIT"
+homepage: "https://github.com/vyos/vyos1x-config"
+bug-reports: "https://phabricator.vyos.net"
+depends: [
+  "alcotest" {= "1.7.0"}
+  "angstrom" {= "0.16.0"}
+  "angstrom-lwt-unix" {= "0.16.0"}
+  "astring" {= "0.8.5"}
+  "base" {= "v0.17.0"}
+  "base-bigarray" {= "base"}
+  "base-bytes" {= "base"}
+  "base-domains" {= "base"}
+  "base-nnp" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "bigstringaf" {= "0.9.1"}
+  "cmdliner" {= "1.3.0"}
+  "conf-libpcre" {= "1"}
+  "conf-pkg-config" {= "3"}
+  "cppo" {= "1.6.9"}
+  "csexp" {= "1.5.2"}
+  "dap" {= "1.0.6"}
+  "dune" {= "3.15.3"}
+  "dune-configurator" {= "3.15.3"}
+  "earlybird" {= "1.3.2"}
+  "fileutils" {= "0.6.4"}
+  "fmt" {= "0.9.0"}
+  "iter" {= "1.8"}
+  "jane-street-headers" {= "v0.17.0"}
+  "jst-config" {= "v0.17.0"}
+  "logs" {= "0.7.0"}
+  "lru" {= "0.3.1"}
+  "lwt" {= "5.7.0"}
+  "lwt_ppx" {= "2.1.0"}
+  "lwt_react" {= "1.2.0"}
+  "menhir" {= "20231231"}
+  "menhirCST" {= "20231231"}
+  "menhirLib" {= "20231231"}
+  "menhirSdk" {= "20231231"}
+  "num" {= "1.5"}
+  "ocaml" {= "5.1.1"}
+  "ocaml-base-compiler" {= "5.1.1"}
+  "ocaml-compiler-libs" {= "v0.12.4"}
+  "ocaml-config" {= "3"}
+  "ocaml-options-vanilla" {= "1"}
+  "ocaml-syntax-shims" {= "1.0.0"}
+  "ocaml_intrinsics_kernel" {= "v0.17.0"}
+  "ocamlbuild" {= "0.14.3"}
+  "ocamlfind" {= "1.9.6"}
+  "ocplib-endian" {= "1.2"}
+  "parsexp" {= "v0.17.0"}
+  "path_glob" {= "0.3"}
+  "pcre" {= "7.5.0"}
+  "ppx_assert" {= "v0.17.0"}
+  "ppx_base" {= "v0.17.0"}
+  "ppx_cold" {= "v0.17.0"}
+  "ppx_compare" {= "v0.17.0"}
+  "ppx_derivers" {= "1.2.1"}
+  "ppx_deriving" {= "6.0.2"}
+  "ppx_deriving_yojson" {= "3.8.0"}
+  "ppx_enumerate" {= "v0.17.0"}
+  "ppx_expect" {= "v0.17.0"}
+  "ppx_globalize" {= "v0.17.0"}
+  "ppx_hash" {= "v0.17.0"}
+  "ppx_here" {= "v0.17.0"}
+  "ppx_inline_test" {= "v0.17.0"}
+  "ppx_optcomp" {= "v0.17.0"}
+  "ppx_sexp_conv" {= "v0.17.0"}
+  "ppxlib" {= "0.32.1"}
+  "ppxlib_jane" {= "v0.17.0"}
+  "psq" {= "0.2.1"}
+  "re" {= "1.11.0"}
+  "react" {= "1.2.2"}
+  "seq" {= "base"}
+  "sexplib" {= "v0.17.0"}
+  "sexplib0" {= "v0.17.0"}
+  "stdio" {= "v0.17.0"}
+  "stdlib-shims" {= "0.3.0"}
+  "time_now" {= "v0.17.0"}
+  "topkg" {= "1.0.7"}
+  "uutf" {= "1.0.3"}
+  "xml-light" {= "2.5"}
+  "yojson" {= "2.1.2"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name]
+]
+dev-repo: "git+https://github.com/vyos/vyos1x-config/"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Implements validation of node children, allowing for declarative validation through XML schemas

*NOTE*: remember to change the container library pinning: https://github.com/vyos/vyos-build/blob/257496d6bf022c36bd13651b247921b2f22c6db6/docker/Dockerfile#L156

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): Added test case

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T5083

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/3575

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->

OPAM must be setup to function properly, and dependencies must be installed.
```
apt-get install -y opam
opam init --auto-setup --disable-sandboxing
eval $(opam env)
make deps
```

Makefile runs the test case

```
# make test
+ dune clean
+ rm -rf test/testresults
+ opam install -y .
[WARNING] Running as root is not recommended
[NOTE] Ignoring uncommitted changes in /workspaces/vyos1x-config (`--working-dir' not active).
[vyos1x-config.0.2] synchronised (git+file:///workspaces/vyos1x-config#T5083)
The following actions will be performed:
  - recompile vyos1x-config 0.2*

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> removed   vyos1x-config.0.2
-> installed vyos1x-config.0.2
Done.
+ dune build ./test/
+ cd _build/default/test/             
+ dune exec ./test_vyos1x.bc
Entering directory '/workspaces/vyos1x-config'
Leaving directory '/workspaces/vyos1x-config'
Testing `Test Suite'.                
This run has ID `FS2CCJWK'.

  [OK]          InterfaceDefinitions          0   can greet Tom.
  [OK]          InterfaceDefinitions          1   Generate xml to json cache.

Full test results in `/workspaces/vyos1x-config/_build/default/test/_build/_tests/Test Suite'.
Test Successful in 0.005s. 2 tests run.
+ cd /workspaces/vyos1x-config
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
