### PR TITLE
renderer: T6742: make childless non-leaf nodes from parsed configs render correctly

### DIFF
--- a/src/config_tree.ml
+++ b/src/config_tree.ml
@@ -30,7 +30,7 @@ let op_to_string op =
     | Delete -> "delete"
 
 let replace_value node path value =
-  let data = {default_data with values=[value]} in
+  let data = {default_data with values=[value]; leaf=true} in
   Vytree.update node path data
 
 let add_value node path value =

--- a/src/config_tree.ml
+++ b/src/config_tree.ml
@@ -41,12 +41,12 @@ let add_value node path value =
   | Some _ -> raise Duplicate_value
   | None ->
     let values = values @ [value] in
-    Vytree.update node path ({data with values=values})
+    Vytree.update node path ({data with values=values; leaf=true})
 
 let delete_value node path value =
     let data = Vytree.data_of_node @@ Vytree.get node path in
     let values = Vylist.remove (fun x -> x = value) data.values in
-    Vytree.update node path {data with values=values}
+    Vytree.update node path {data with values=values; leaf=true}
 
 let set_value node path value behaviour =
     match behaviour with

--- a/src/config_tree.mli
+++ b/src/config_tree.mli
@@ -10,6 +10,7 @@ type config_node_data = {
   values : string list;
   comment : string option;
   tag : bool;
+  leaf: bool;
 } [@@deriving yojson]
 
 type t = config_node_data Vytree.t [@@deriving yojson]
@@ -17,6 +18,8 @@ type t = config_node_data Vytree.t [@@deriving yojson]
 val default_data : config_node_data
 
 val make : string -> t
+
+val create_node : t -> string list -> t
 
 val set : t -> string list -> string option -> value_behaviour -> t
 
@@ -33,6 +36,10 @@ val get_comment : t -> string list -> string option
 val set_tag : t -> string list -> bool -> t
 
 val is_tag : t -> string list -> bool
+
+val set_leaf : t -> string list -> bool -> t
+
+val is_leaf : t -> string list -> bool
 
 val get_subtree : ?with_node:bool -> t -> string list -> t
 

--- a/src/vyos1x_parser.mly
+++ b/src/vyos1x_parser.mly
@@ -49,10 +49,10 @@ value:
 leaf_node_body:
   | comment = comments;
     name = IDENTIFIER; value = value;
-    { Vytree.make_full {default_data with values=[value]; comment=comment} name []}
+    { Vytree.make_full {default_data with values=[value]; comment=comment; leaf=true} name []}
   | comment = comments;
     name = IDENTIFIER; (* valueless node *)
-    { Vytree.make_full {default_data with comment=comment} name [] }
+    { Vytree.make_full {default_data with comment=comment; leaf=true} name [] }
 ;
 
 leaf_node:

--- a/vyos1x-config.opam
+++ b/vyos1x-config.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "vyos1x-config"
-version: "0.2"
+version: "0.3"
 synopsis: "VyOS 1.x and EdgeOS config file manipulation library"
 description: """
 A library for parsing, manipulating, and exporting VyOS 1.x and EdgeOS config files.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

At the moment, the renderer shows all nodes without children as valueless leaf nodes, which is incorrect. So, we should:

* Add an explicit `leaf` flag to node data.
* Set that flag in the parser for nodes presented as leaf nodes in the config text.
* Use the flag to correctly render parsed configs with empty pairs of braces after childless non-leaf nodes.
* Add a function to create non-leaf nodes without values.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Proposed changes
<!--- Describe your changes in detail -->

## How to test

```
utop # Vyos1x.Parser.from_string {|
system {
  /* This is a non-leaf childless node */
  login {
  }
}

|} |> Vyos1x.Config_tree.render_config |> Printf.printf "Rendered config:\n\n%s\n" ;;
Rendered config:

system {
    /* This is a non-leaf childless node */
    login {
    }
}

- : unit = ()

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
