### PR TITLE
T6342: add parsing of docs element

### DIFF
--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -20,6 +20,18 @@ type completion_help_type =
     | Script of string [@name "script"]
     [@@deriving yojson]
 
+type doc_hints = {
+        text: string;
+        hint_type: string;
+    } [@@deriving yojson]
+
+type docs = {
+        headline: string;
+        text: string;
+        usageExample: string;
+        hints: doc_hints list;
+    } [@@deriving yojson]
+
 type ref_node_data = {
     node_type: node_type;
     constraints: Value_checker.value_constraint list;
@@ -35,6 +47,7 @@ type ref_node_data = {
     default_value: string option;
     hidden: bool;
     secret: bool;
+    docs: docs;
 } [@@deriving yojson]
 
 type t = ref_node_data Vytree.t [@@deriving yojson]
@@ -58,6 +71,12 @@ let default_data = {
     default_value = None;
     hidden = false;
     secret = false;
+    docs = {
+        headline = "";
+        text = "";
+        usageExample = "";
+        hints = [];
+    };
 }
 
 let default = Vytree.make default_data ""
@@ -155,6 +174,38 @@ let load_constraint_group_from_xml d c =
         | _ -> raise (Bad_interface_definition ("Malformed constraint: " ^ Xml.to_string c))
     in Xml.fold aux d c
 
+let load_docs_hints d c =
+    let aux d c =
+        match c with
+        | Xml.Element ("hints", attrs, [Xml.PCData s]) ->
+            let hint_type = List.assoc "type" attrs in
+            let hint = { text = s; hint_type = hint_type } in
+            let new_docs = { d.docs with hints = hint :: d.docs.hints } in
+            { d with docs = new_docs }
+        | _ -> raise (Bad_interface_definition ("Malformed hint: " ^ Xml.to_string c))
+    in aux d c
+
+let load_docs_from_xml d x =
+    let aux d x =
+        match x with
+        | Xml.Element ("headline", _, [Xml.PCData s]) -> 
+            let new_docs = {d.docs with headline = s} in 
+            {d with docs = new_docs}
+        | Xml.Element ("text", _, [Xml.PCData s]) -> 
+            let new_docs = {d.docs with text = s} in 
+            {d with docs = new_docs}
+        | Xml.Element ("hints", _, _) -> 
+            load_docs_hints d x
+        | Xml.Element ("usageExample", _, [Xml.PCData s]) -> 
+            let new_docs = {d.docs with usageExample = s} in 
+            {d with docs = new_docs}
+        | _ -> d  (* Ignore unknown elements instead of raising an error *)
+    in
+    match x with
+    | Xml.Element ("docs", _, children) ->
+        List.fold_left aux d children 
+    | _ -> d
+
 let data_from_xml d x =
     let aux d x =
         match x with
@@ -172,6 +223,7 @@ let data_from_xml d x =
             {d with priority=Some i}
         | Xml.Element ("hidden", _, _) -> {d with hidden=true}
         | Xml.Element ("secret", _, _) -> {d with secret=true}
+        | Xml.Element ("docs", _, _) -> load_docs_from_xml d x
         | _ -> raise (Bad_interface_definition ("Malformed property tag: " ^ Xml.to_string x))
     in Xml.fold aux d x
 

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -21,16 +21,16 @@ type completion_help_type =
     [@@deriving yojson]
 
 type doc_hints = {
-        text: string;
-        hint_type: string;
-    } [@@deriving yojson]
+    text: string;
+    hint_type: string;
+} [@@deriving yojson]
 
 type docs = {
-        headline: string;
-        text: string;
-        usageExample: string;
-        hints: doc_hints list;
-    } [@@deriving yojson]
+    headline: string;
+    text: string;
+    usageExample: string;
+    hints: doc_hints list;
+} [@@deriving yojson]
 
 type ref_node_data = {
     node_type: node_type;
@@ -188,23 +188,19 @@ let load_docs_hints d c =
 let load_docs_from_xml d x =
     let aux d x =
         match x with
-        | Xml.Element ("headline", _, [Xml.PCData s]) -> 
-            let new_docs = {d.docs with headline = s} in 
+        | Xml.Element ("headline", _, [Xml.PCData s]) ->
+            let new_docs = {d.docs with headline = s} in
             {d with docs = new_docs}
-        | Xml.Element ("text", _, [Xml.PCData s]) -> 
-            let new_docs = {d.docs with text = s} in 
+        | Xml.Element ("text", _, [Xml.PCData s]) ->
+            let new_docs = {d.docs with text = s} in
             {d with docs = new_docs}
-        | Xml.Element ("hints", _, _) -> 
+        | Xml.Element ("hints", _, _) ->
             load_docs_hints d x
-        | Xml.Element ("usageExample", _, [Xml.PCData s]) -> 
-            let new_docs = {d.docs with usageExample = s} in 
+        | Xml.Element ("usageExample", _, [Xml.PCData s]) ->
+            let new_docs = {d.docs with usageExample = s} in
             {d with docs = new_docs}
         | _ -> d  (* Ignore unknown elements instead of raising an error *)
-    in
-    match x with
-    | Xml.Element ("docs", _, children) ->
-        List.fold_left aux d children 
-    | _ -> d
+    in Xml.fold aux d x
 
 let data_from_xml d x =
     let aux d x =

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -9,6 +9,18 @@ type completion_help_type =
     | Script of string [@name "script"]
     [@@deriving yojson]
 
+type doc_hints = {
+        text: string;
+        hint_type: string;
+    } [@@deriving yojson]
+
+type docs = {
+    headline: string;
+    text: string;
+    usageExample: string;
+    hints: doc_hints list;
+    } [@@deriving to_yojson]
+
 type ref_node_data = {
     node_type: node_type;
     constraints: Value_checker.value_constraint list;
@@ -24,6 +36,7 @@ type ref_node_data = {
     default_value: string option;
     hidden: bool;
     secret: bool;
+    docs: docs;
 } [@@deriving yojson]
 
 type t = ref_node_data Vytree.t [@@deriving yojson]

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -10,16 +10,16 @@ type completion_help_type =
     [@@deriving yojson]
 
 type doc_hints = {
-        text: string;
-        hint_type: string;
-    } [@@deriving yojson]
+    text: string;
+    hint_type: string;
+} [@@deriving yojson]
 
 type docs = {
     headline: string;
     text: string;
     usageExample: string;
     hints: doc_hints list;
-    } [@@deriving to_yojson]
+} [@@deriving to_yojson]
 
 type ref_node_data = {
     node_type: node_type;


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add support to parse `<docs>` elements from xml


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6342

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/4292

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
