### PR TITLE
T7246: drop lexer rule ignoring lines beginning with '//'

### DIFF
--- a/src/vyos1x_lexer.mll
+++ b/src/vyos1x_lexer.mll
@@ -69,8 +69,6 @@ rule token vy_inside_node = parse
     { (false, LEFT_BRACE) }
 | '}'
     { (false, RIGHT_BRACE) }
-| "//" [^ '\n']*
-    { token vy_inside_node lexbuf }
 | [^ ' ' '\t' '\n' '\r' '{' '}' '"' ''' ]+ as s
     { (true, IDENTIFIER s) }
 | eof


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The lexer is unnecessarily aggressive in disallowing strings following '//', originally added to ignore version string information. This has the side effect of ignoring legitimate values. Since the version string is now extracted before parsing, this restriction can be dropped.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
