### PR TITLE
T7694: insert paths lexical-numerically in config_tree set

### DIFF
--- a/src/config_tree.ml
+++ b/src/config_tree.ml
@@ -72,7 +72,7 @@ let set node path value behaviour =
         let path_remaining = Vylist.complement path path_existing in
         let values = match value with None -> [] | Some v -> [v] in
         let end_data = {default_data with values=values; leaf=true} in
-        Vytree.insert_multi_level default_data node path_existing path_remaining end_data
+        Vytree.insert_multi_level ~position:Lexical default_data node path_existing path_remaining end_data
 
 let get_values node path =
     let node' = Vytree.get node path in

--- a/src/vytree.ml
+++ b/src/vytree.ml
@@ -142,13 +142,13 @@ let merge_children merge_data cmp node =
 
 (* When inserting at a path that, entirely or partially,
    does not exist yet, create missing nodes on the way with default data *)
-let rec insert_multi_level default_data node path_done path_remaining data =
+let rec insert_multi_level ?(position=Default) default_data node path_done path_remaining data =
     match path_remaining with
     | [] | [_] -> insert node (path_done @ path_remaining) data
     | name :: names ->
         let path_done = path_done @ [name] in
-        let node = insert node path_done default_data in
-        insert_multi_level default_data node path_done names data
+        let node = insert ~position:position node path_done default_data in
+        insert_multi_level ~position:position default_data node path_done names data
 
 let delete node path =
     do_with_child delete_immediate node path

--- a/src/vytree.mli
+++ b/src/vytree.mli
@@ -27,7 +27,7 @@ val insert_maybe : ?position:position -> 'a t -> string list -> 'a -> 'a t
 
 val insert_or_update : ?position:position -> 'a t -> string list -> 'a -> 'a t
 
-val insert_multi_level : 'a -> 'a t -> string list -> string list -> 'a -> 'a t
+val insert_multi_level : ?position:position -> 'a -> 'a t -> string list -> string list -> 'a -> 'a t
 
 val merge_children : ('a -> 'a -> 'a) -> (string -> string -> int) -> 'a t -> 'a t
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Insert new paths/tag-node values using the compare function `Util.lexical_numeric_compare`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
