### PR TITLE
T7737: add utils for analogue of configfs

### DIFF
--- a/src/config_tree.ml
+++ b/src/config_tree.ml
@@ -1,4 +1,4 @@
-type value_behaviour = AddValue | ReplaceValue
+type value_behaviour = AddValue | ReplaceValue [@@deriving yojson]
 type command = Set | Delete
 
 exception Duplicate_value

--- a/src/config_tree.mli
+++ b/src/config_tree.mli
@@ -1,4 +1,4 @@
-type value_behaviour = AddValue | ReplaceValue
+type value_behaviour = AddValue | ReplaceValue [@@deriving yojson]
 type command = Set | Delete
 
 exception Duplicate_value

--- a/src/vylist.ml
+++ b/src/vylist.ml
@@ -10,11 +10,15 @@ let rec remove p xs =
     | y :: ys -> if (p y) then ys
                  else y :: (remove p ys)
 
-let rec replace p x xs =
-    match xs with
-    | [] -> raise Not_found
-    | y :: ys -> if (p y) then x :: ys
-                 else y :: (replace p x ys)
+let rec replace ?(force=false) p x xs =
+    try
+        match xs with
+        | [] -> raise_notrace Not_found
+        | y :: ys -> if (p y) then x :: ys
+                     else y :: (replace p x ys)
+    with Not_found ->
+        if force then (x :: xs)
+        else raise Not_found
 
 let rec insert_before p x xs =
     match xs with

--- a/src/vylist.mli
+++ b/src/vylist.mli
@@ -1,6 +1,6 @@
 val find : ('a -> bool) -> 'a list -> 'a option
 val remove : ('a -> bool) -> 'a list -> 'a list
-val replace : ('a -> bool) -> 'a -> 'a list -> 'a list
+val replace : ?force:bool -> ('a -> bool) -> 'a -> 'a list -> 'a list
 val insert_before : ('a -> bool) -> 'a -> 'a list -> 'a list
 val insert_after : ('a -> bool) -> 'a -> 'a list -> 'a	list
 val insert_compare : ('a -> 'a -> int) -> 'a -> 'a list -> 'a list


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Simple utils for vyconf support for auxiliary updates to config during commit, analogous to the configfs module.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
