### PR TITLE
T7980: add write_internal_atomic to cache config in presence of readers

### DIFF
--- a/src/internal.ml
+++ b/src/internal.ml
@@ -1,3 +1,8 @@
+(*
+ * A functor for 'internal' representation of Config_tree and Reference_tree.
+ * This is useful for avoiding re-parsing *_trees on cache and load.
+ *)
+
 exception Read_error of string
 exception Write_error of string
 

--- a/src/internal.ml
+++ b/src/internal.ml
@@ -17,6 +17,7 @@ module type T =
 module type FI = functor (M: T) ->
     sig
         val write_internal : M.t -> string -> unit
+        val write_internal_atomic : M.t -> string -> unit
         val read_internal : string -> M.t
         val replace_internal : string -> string -> unit
     end
@@ -48,6 +49,26 @@ module Make : FI = functor (M: T) -> struct
         let ct_res = M.of_yojson yt in
         let ct = Result.value ct_res ~default:M.default in
         close_in_noerr ic; ct
+
+    let write_internal_atomic x file_name =
+        let file_name_tmp = file_name ^ ".tmp" in
+        let yt = M.to_yojson x in
+        let ys = Yojson.Safe.to_string yt in
+        let fd =
+            try
+                Unix.openfile file_name_tmp [Unix.O_CREAT;Unix.O_WRONLY] 0o664
+            with Unix.Unix_error (e,f,p) ->
+                let out =
+                    Printf.sprintf "%s %s: %s" (Unix.error_message e) f p
+                in raise (Write_error out)
+        in
+        let oc = Unix.out_channel_of_descr fd in
+        let () = Unix.ftruncate fd 0 in
+        let () = Printf.fprintf oc "%s" ys in
+        let () = Unix.fsync fd in
+        let () = Unix.chmod file_name_tmp 0o664 in
+        let () = Unix.rename file_name_tmp file_name in
+        close_out_noerr oc
 
     let replace_internal dst src =
         let tmp = src ^ ".tmp" in

--- a/src/internal.mli
+++ b/src/internal.mli
@@ -12,6 +12,7 @@ module type T =
 module type FI = functor (M : T) ->
     sig
       val write_internal : M.t -> string -> unit
+      val write_internal_atomic : M.t -> string -> unit
       val read_internal : string -> M.t
       val replace_internal : string -> string -> unit
     end


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

A general use function to support the loading of (a quick loading representation of) the active config on vyconfd restart. Although the active config is cached under a commit lock (at commit completion, before lock released), we use rename to allow unsynchronized reads from op-mode without waiting on the commit lock.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): add missing internal feature

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyconf/pull/34
https://github.com/vyos/vyos-1x/pull/4827

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
