### PR TITLE
T8032: add file_compare utility for comparing files up to whitespace

### DIFF
--- a/src/util.ml
+++ b/src/util.ml
@@ -172,3 +172,55 @@ let flag path =
         drop_last_n p (len - i - 1)
     in
     List.mapi (fun k _ -> aux path k) path
+
+
+exception End_of_read of in_channel
+
+let file_compare ?(ignore_line_prefix="") file1 file2 =
+    let open_files f1 f2 =
+        let ic1_opt =
+            try Some (open_in f1)
+            with Sys_error _ -> None
+        in
+        let ic2_opt =
+            try Some (open_in f2)
+            with Sys_error _ -> None
+        in
+        ic1_opt, ic2_opt
+    in
+    let rec line_loop ic =
+        let line =
+            try
+                input_line ic
+            with End_of_file -> raise (End_of_read ic)
+        in
+        let line' = String.trim line in
+        if line' <> "" &&
+            (ignore_line_prefix = "" ||
+             not (String.starts_with ~prefix:ignore_line_prefix line'))
+        then line'
+        else line_loop ic
+    in
+    let rec loop ic1 ic2 =
+        try
+            let line1 = line_loop ic1 in
+            let line2 = line_loop ic2 in
+            if line1 <> line2 then false
+            else loop ic1 ic2
+        with End_of_read ic ->
+            try
+                if ic = ic1 then
+                    let () = ignore (line_loop ic2) in false
+                else false
+            with End_of_read _ ->
+              true
+    in
+    match open_files file1 file2 with
+    | Some ic1, Some ic2 ->
+        let result = loop ic1 ic2 in
+        close_in ic1;
+        close_in ic2;
+        result
+    | Some ic1, None -> close_in ic1; false
+    | None, Some ic2 -> close_in ic2; false
+    | None, None -> false

--- a/src/util.mli
+++ b/src/util.mli
@@ -35,3 +35,8 @@ val is_empty : 'a list -> bool
 val is_sublist : 'a list -> 'a list -> bool
 
 val flag : 'a list -> 'a list list
+
+
+exception End_of_read of in_channel
+
+val file_compare : ?ignore_line_prefix:string -> string -> string -> bool


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

It is useful to have an internal implementation of `file_compare` (T8031) for use in the vyconf replacement for cli-shell-api sessionUnsaved in shell functions. Add here.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): vyconf integration with CLI

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
