### PR TITLE
T8109: fix show command on leaf path

### DIFF
--- a/src/config_diff.ml
+++ b/src/config_diff.ml
@@ -699,7 +699,13 @@ let diff_show rt path left right =
     else
         let (left, right) =
             if not (Util.is_empty path) then
-            (Config_tree.get_subtree left path, Config_tree.get_subtree right path)
+            let with_node =
+            match Reference_tree.get_path_type rt path with
+            | `Leaf -> true
+            | _ -> false
+            in
+            (Config_tree.get_subtree ~with_node left path,
+            Config_tree.get_subtree ~with_node right path)
             else (left, right)
         in
         let config_show = make_diff_show left right path in


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Correctly display leaf node name/value when path contains leaf node as last component. Previously, output was empty, as rendering was occurring 'below' leaf node (i.e., empty).

```
vyos@vyos# show interfaces ethernet eth2 description 
+description "foo"

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
