### PR TITLE
T8156: fix misplaced check for Nonexistent_path in get completion env

### DIFF
--- a/src/completion.ml
+++ b/src/completion.ml
@@ -85,17 +85,14 @@ let get_completion_env rtree ctree op cpath =
         let cnode =
             match path with
             | [] -> ctree
-            | _ -> (Vytree.get[@alert "-exn"]) ctree path
+            | _ -> try (Vytree.get[@alert "-exn"]) ctree path
+                   with Vytree.Nonexistent_path -> Config_tree.default
         in
         let children =
             let child_set = Vytree.children_of_node rnode in
             if not restricted then child_set
             else
-            let extant_children =
-                try
-                    Vytree.list_children cnode
-                with Vytree.Nonexistent_path -> []
-            in
+            let extant_children = Vytree.list_children cnode in
             let is_extant s =
                 List.mem (Vytree.name_of_node s) extant_children
             in


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

A missed/misplaced check in https://github.com/vyos/vyos1x-config/pull/59 allows an error on tab completion along new paths. A simple fix.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
