### PR TITLE
T8157: add missed case of vyconf completion, in the absence of valueHelp

### DIFF
--- a/src/completion.ml
+++ b/src/completion.ml
@@ -134,13 +134,19 @@ let get_completion_env_str ?(legacy_format=false) rtree ctree op cpath =
         let (comp_vals, comp_val, comp_help, help_format, help_string) =
         match path_typ with
         | `Tag | `Leaf | `Multi ->
-            let (compl_vals, _, _, value_help) =
+            let (compl_vals, _, help, value_help) =
                 let a, b, c, d =
                     List.fold_left func ([], [], [], []) comp in
                 List.rev a, b, c, List.rev d
             in
             let value_help_fmt, value_help_string = List.split value_help in
-            (compl_vals, true, "", value_help_fmt, value_help_string)
+            begin
+            match value_help_string with
+            | [] ->
+                (compl_vals, true, "", ["txt"], help)
+            | _ ->
+                (compl_vals, true, "", value_help_fmt, value_help_string)
+            end
         | `Other | `Tag_value ->
             let (compl_vals, _, help, _) =
                 let sorted_comp =


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Integrating vyconf with existing bash completion requires coordinating the minutiae of the cli-shell-api; this PR adds the missed case here:
https://github.com/vyos/vyatta-cfg/blob/current/src/cstore/cstore.cpp#L864-L868

A simple example requires the addition of the bug fix contained in
https://github.com/vyos/vyos1x-config/pull/62
Assuming that, we can compare:

Legacy behavior:

```
vyos@vyos# set netns name <tab>
Possible completions:
 > <text>               Network namespace name
 >                      

      
[edit]
```

Vyconf behavior without this fix:

```
vyos@vyos# set netns name <tab>
Possible completions:
 >                      

      
[edit]
```

Vyconf behavior with fix:

```
vyos@vyos# set netns name <tab>
Possible completions:
 > <text>               Network namespace name
 >                      

      
[edit]
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
