### PR TITLE
T8164: add completion help hints to get_completion_env

### DIFF
--- a/src/completion.ml
+++ b/src/completion.ml
@@ -32,6 +32,33 @@ let get_completion_data (node: Reference_tree.t) =
       value_help=data.value_help;
     }
 
+let execute_completion_script cmd =
+    let () = Unix.putenv "vyos_completion_dir" "/usr/libexec/vyos/completion" in
+    let chan = Unix.open_process_in cmd in
+    let out = In_channel.input_all chan in
+    let result = Unix.close_process_in chan in
+    match result with
+    | Unix.WEXITED 0 -> out
+    | _ -> ""
+
+let read_completion_help ctree (lst: Reference_tree.completion_help_type list) =
+    let read_elem chelp =
+        match chelp with
+        | Reference_tree.List l -> Util.list_of_string l
+        | Reference_tree.Path p ->
+            begin
+            let path = Util.list_of_string p in
+            try (Vytree.children_of_path[@alert "-exn"]) ctree path
+            with Vytree.Empty_path | Vytree.Nonexistent_path -> []
+            end
+        | Reference_tree.Script s ->
+            Util.list_of_string (execute_completion_script s)
+    in
+    let func acc elem =
+        acc @ (read_elem elem)
+    in
+    List.fold_left func [] lst
+
 let get_completion_env rtree ctree op cpath =
     let op = op_of_string op in
     match op with
@@ -60,20 +87,34 @@ let get_completion_env rtree ctree op cpath =
     | `Leaf | `Multi ->
         let compl_env =
             get_completion_data ((Vytree.get[@alert "-exn"]) rtree rpath) in
+        let comp_help = read_completion_help ctree compl_env.completion_help
+        in
         let values =
-            try
-                (Config_tree.get_values[@alert "-exn"]) ctree path
-            with Vytree.Nonexistent_path -> []
+            match comp_help with
+            | [] ->
+                begin
+                try
+                    (Config_tree.get_values[@alert "-exn"]) ctree path
+                with Vytree.Nonexistent_path -> []
+                end
+            | _ as l -> l
         in
         Ok [{ compl_env with values = values; path_typ = `Leaf_value }]
     | `Tag ->
         let compl_env =
             get_completion_data ((Vytree.get[@alert "-exn"]) rtree rpath)
         in
+        let comp_help = read_completion_help ctree compl_env.completion_help
+        in
         let values =
-            try
-                Vytree.list_children ((Vytree.get[@alert "-exn"]) ctree path)
-            with Vytree.Nonexistent_path -> []
+            match comp_help with
+            | [] ->
+                begin
+                try
+                    Vytree.list_children ((Vytree.get[@alert "-exn"]) ctree path)
+                with Vytree.Nonexistent_path -> []
+                end
+            | _ as l -> l
         in
         Ok [{ compl_env with values = values; path_typ = `Tag_value }]
     | _ ->

--- a/src/util.ml
+++ b/src/util.ml
@@ -102,7 +102,11 @@ let json_of_list ss =
     let ss = List.map (fun x -> `String x) ss in
     Yojson.Safe.to_string (`List ss)
 
-(** Split string on whitespace, excluding single-quoted phrases,
+(** Split string on whitespace *)
+let list_of_string s =
+    Pcre2.split ~pat:"\\s+" s
+
+(** Split string on whitespace, excluding last if single-quoted value,
     as needed for parsing vyconf request path option **)
 let list_of_path p =
     let seg = String.trim p |> String.split_on_char '\'' in

--- a/src/util.mli
+++ b/src/util.mli
@@ -14,6 +14,8 @@ val string_of_list : string list -> string
 
 val json_of_list : string list -> string
 
+val list_of_string : string -> string list
+
 val list_of_path : string -> string list
 
 val drop_last : 'a list -> 'a list


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add hints from XML `completionHelp` element to the `get_completion_env` call used by bash completion as a vyconf replacement for `cli-shell-api getCompletionEnv`. In fact, this is the lesser, and easier, part of the construction of `get_completion_env`, hence added once the framework was complete.

N.B.: the general use of `open_proces_in` here, and its existing use for calling validators, will be replaced by their execve counterparts in https://vyos.dev/T8173.

Example for completion script:

Legacy:

```
vyos@vyos# set service ipoe-server interface <tab>
Possible completions:
 > <text>               Interface to listen dhcp or unclassified packets
 > eth0                 
 > eth1                 
 > eth2                 
 > eth3                 
 > lo                   

      
[edit]
```

Modern with this PR:

```
vyos@vyos:~$ sudo /usr/libexec/vyos/set_vyconf_backend.py 
This will enable the vyconf backend for testing. Proceed? [y/N] y
vyos@vyos:~$ config
[edit]
vyos@vyos# set service ipoe-server interface <tab>
Possible completions:
 > <text>               Interface to listen dhcp or unclassified packets
 > eth0                 
 > eth1                 
 > eth2                 
 > eth3                 
 > lo                   

      
[edit]
```

Without the PR, the list of interfaces above are not populated when running under vyconf.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): integration of vyconf with shell internal functions and completion

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
