### PR TITLE
T8269: handle element constraintSilenceOutput in creation of ref tree

### DIFF
--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -50,6 +50,7 @@ type ref_node_data = {
     constraints: Value_checker.value_constraint list;
     constraint_group: Value_checker.value_constraint list;
     constraint_error_message: string;
+    constraint_silence_output: bool;
     completion_help: completion_help_type list;
     help: string;
     value_help: (string * string) list;
@@ -74,6 +75,7 @@ let default_data = {
     constraints = [];
     constraint_group = [];
     constraint_error_message = "Invalid value";
+    constraint_silence_output = false;
     completion_help = [];
     help = "No help available";
     value_help = [];
@@ -230,6 +232,7 @@ let data_from_xml d x =
             {d with constraint_error_message=s}
         | Xml.Element ("constraint", _, _) -> load_constraint_from_xml d x
         | Xml.Element ("constraintGroup", _, _) -> load_constraint_group_from_xml d x
+        | Xml.Element ("constraintSilenceOutput", _, _) -> {d with constraint_silence_output=true}
         | Xml.Element ("priority", _, [Xml.PCData i]) ->
             {d with priority=Some i}
         | Xml.Element ("hidden", _, _) -> {d with hidden=true}

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -28,6 +28,7 @@ type ref_node_data = {
     constraints: Value_checker.value_constraint list;
     constraint_group: Value_checker.value_constraint list;
     constraint_error_message: string;
+    constraint_silence_output: bool;
     completion_help: completion_help_type list;
     help: string;
     value_help: (string * string) list;


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add support for new schema element `constraintSilenceOutput`, used in suppressing individual validator messages in cases where only `constraintErrorMessage` is appropriate. cf. example in https://vyos.dev/T8269; individual error output is misleading:

```
vyos@vyos# set protocols bgp neighbor 172.18.20

  Incorrect path /sys/class/net/172.18.20: no such file or directory

  Error: 172.18.20 is not a valid IP address



  Invalid value
  Value validation failed
  Set failed
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): handle added schema element

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
