### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,3 @@ Canonical side. Twin at `VyOS-Networks/vyos1x-config` is force-pushed by the mir
 - Keep parser changes backwards compatible; existing configs and migration scripts depend on round-trip stability.
 - LICENSE (LGPL-2.1) vs opam (MIT) mismatch is worth resolving before any non-trivial relicensing scenario.
 - `vyconf` (still early-stage per its README) is a fellow OCaml consumer; coordinate API changes with that repo.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos1x-config`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/817889797). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+## Project purpose
+Pure-OCaml library that parses, manipulates, and serializes VyOS 1.x and EdgeOS configuration files. The data layer that the rest of the VyOS config stack is built on.
+
+## Tech stack
+- OCaml; `dune` 2.0 with `menhir` (parser); `ppx_deriving_yojson`, `yojson` for JSON I/O.
+- `opam`: `vyos1x-config.opam` declares version `0.3`, MIT license, deps `ocamlfind`, `menhir`, `dune >= 1.4.0`, `ppx_deriving_yojson <= 3.9.1`, `yojson`.
+- License: LGPL-2.1 in tree (`LICENSE`); opam declares `MIT` (note the discrepancy if redistributing).
+
+## Build / test / run
+- Local: `opam install . --deps-only` then `dune build -p vyos1x-config`.
+- Install: `dune install` (or via opam-pin).
+- No `dune runtest` suite in tree; coverage comes from `libvyosconfig` and `vyos-1x` smoketests downstream.
+
+## Repository layout
+- `src/` — OCaml sources (parser via menhir, AST, serializers).
+- `dune-project`, `vyos1x-config.opam` — build/package metadata.
+- `.github/workflows/` — `check-pr-conflicts.yml`, `cla-check.yml`, `pr-mirror-repo-sync.yml` — all delegate to `vyos/.github` reusables.
+
+## Cross-repo context
+- Wrapped by `VyOS-Networks/libvyosconfig` (OCaml→C shim producing `libvyosconfig0.so`) which is also vendored inside `vyos/vyos-1x/libvyosconfig/` as the canonical build source for the Debian package.
+- Consumed (via `libvyosconfig0`) by `vyos/vyos-1x`'s `python/vyos/configtree.py` (ctypes binding) and by the legacy C++ Vyatta layer.
+- `vyos/vyconf` (config-session daemon, OCaml) depends on this library directly.
+- Live consumer of the generation-1 mirror pipeline (`pr-mirror-repo-sync.yml@current`).
+
+## Conventions
+- Commit / PR title: `component: T12345: description` (Phorge ID mandatory).
+- Default branch `current`; backports via `@Mergifyio backport <branch>`.
+- Reusable workflows pinned `@current` — changes in `vyos/.github` ship immediately.
+
+## Mirror relationship
+Canonical side. Twin at `VyOS-Networks/vyos1x-config` is force-pushed by the mirror pipeline; do not edit it.
+
+## Notes for future contributors
+- This is a load-bearing library — every `commit` operation against VyOS goes through it. Add tests at the `libvyosconfig`/`vyos-1x` layers, not just locally.
+- Keep parser changes backwards compatible; existing configs and migration scripts depend on round-trip stability.
+- LICENSE (LGPL-2.1) vs opam (MIT) mismatch is worth resolving before any non-trivial relicensing scenario.
+- `vyconf` (still early-stage per its README) is a fellow OCaml consumer; coordinate API changes with that repo.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos1x-config`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/817889797). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 ## Project purpose
-Pure-OCaml library that parses, manipulates, and serializes VyOS 1.x and EdgeOS configuration files. The data layer that the rest of the VyOS config stack is built on.
+OCaml library that parses, manipulates, and serializes VyOS 1.x and EdgeOS configuration files. The data layer that the rest of the VyOS config stack is built on.
 
 ## Tech stack
 - OCaml; `dune` 2.0 with `menhir` (parser); `ppx_deriving_yojson`, `yojson` for JSON I/O.
@@ -14,7 +14,7 @@ Pure-OCaml library that parses, manipulates, and serializes VyOS 1.x and EdgeOS 
 - No `dune runtest` suite in tree; coverage comes from `libvyosconfig` and `vyos-1x` smoketests downstream.
 
 ## Repository layout
-- `src/` — OCaml sources (parser via menhir, AST, serializers).
+- `src/` — OCaml sources (parser via menhir, AST, serializers) plus `lexical_numeric_compare.c` (small C helper).
 - `dune-project`, `vyos1x-config.opam` — build/package metadata.
 - `.github/workflows/` — `check-pr-conflicts.yml`, `cla-check.yml`, `pr-mirror-repo-sync.yml` — all delegate to `vyos/.github` reusables.
 


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
