### PR TITLE
T8916: Adjustments to calculation of config tree exclusive mask

### DIFF
--- a/src/config_diff.ml
+++ b/src/config_diff.ml
@@ -729,7 +729,7 @@ let mask_func_inclusive ?recurse:_ (path : string list) (Diff_tree res) (m : cha
     | Updated _ -> Diff_tree (res)
 
 (* mask function; mask applied on right *)
-let mask_func_exclusive ?recurse:_ (path : string list) (Diff_tree res) (m : change) =
+let mask_func_exclusive ?(recurse=true) (path : string list) (Diff_tree res) (m : change) =
     (* alert exn Vytree.delete:
         [Vytree.Empty_path] not possible in pattern match case
         [Vytree.Nonexistent_path] not possible as called on existing config paths (res.left)
@@ -742,9 +742,14 @@ let mask_func_exclusive ?recurse:_ (path : string list) (Diff_tree res) (m : cha
     | Unchanged | Updated _ ->
         begin
             match path with
-            | [] -> Diff_tree(res)
+            | [] ->
+                if recurse then
+                    (* in the diff function, recurse = true on an empty path means that the
+                       trees are equal, hence exclude all: return default (empty) tree *)
+                    Diff_tree {res with left = Config_tree.default}
+                else Diff_tree(res)
             | _ ->
-                if ((Vytree.is_terminal_path[@alert "-exn"]) res.right path) then
+                if recurse || ((Vytree.is_terminal_path[@alert "-exn"]) res.right path) then
                     let tmp = (Vytree.delete[@alert "-exn"]) res.left path in
                     let left' = (Config_tree.prune_delete[@alert "-exn"]) tmp path in
                     Diff_tree {res with left = left'}

--- a/src/config_diff.ml
+++ b/src/config_diff.ml
@@ -792,19 +792,19 @@ let subtree_from_partial reftree ctree result path =
         | [] -> false
         | _ -> (Vytree.exists[@alert "-exn"]) ctree p
     in
-    let clone_node tree p =
+    let clone_node ?(recurse=false) tree p =
         if (Vytree.exists[@alert "-exn"]) tree p then
             tree
         else
         if not ((Vytree.exists[@alert "-exn"]) ctree p) then
             tree
         else
-            clone ~recurse:false ctree tree p
+            clone ~recurse:recurse ctree tree p
     in
     let clone_children tree p =
         let children = Vytree.list_children ((Vytree.get[@alert "-exn"]) ctree p) in
         let paths = List.map (fun n -> p @ [n]) children in
-        List.fold_left clone_node tree paths
+        List.fold_left (clone_node ~recurse:true) tree paths
     in
     let rec aux acc path_done p =
         if not (check_reftree (path_done @ p)) then
@@ -833,9 +833,7 @@ let subtree_from_partial reftree ctree result path =
                 else
                 (* [h] is a tag_value not present in the config tree *)
                 raise (Malformed_path (Util.string_of_list p'))
-        | _, [] ->
-                if (Config_tree.is_tag[@alert "-exn"]) ctree path_done then clone_children acc path_done
-                else acc
+        | _, [] -> clone_children acc path_done
     in aux result [] path
 
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Fix two similar errors in the calculation of exclusive masks: missing descent along paths in case of equality. The point is that in the diff algorithm, if the nodes being compared are structurally equal, the burden is passed to the diff function to recurse. In application of the initial version to https://github.com/vyos/vyos-1x/pull/5169, the bug was obscured since the errors in the two instances below cancelled each other in a standard case.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
