### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->rolling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,12 @@ OCaml library that parses, manipulates, and serializes VyOS 1.x and EdgeOS confi
 - Wrapped by an internal repository (OCaml→C shim producing `libvyosconfig0.so`) which is also vendored inside `vyos/vyos-1x/libvyosconfig/` as the canonical build source for the Debian package.
 - Consumed (via `libvyosconfig0`) by `vyos/vyos-1x`'s `python/vyos/configtree.py` (ctypes binding) and by the legacy C++ Vyatta layer.
 - `vyos/vyconf` (config-session daemon, OCaml) depends on this library directly.
-- Live consumer of the generation-1 mirror pipeline (`pr-mirror-repo-sync.yml@current`).
+- Live consumer of the generation-1 mirror pipeline (`pr-mirror-repo-sync.yml@production`).
 
 ## Conventions
 - Commit / PR title: `component: T12345: description` (Phorge ID mandatory).
-- Default branch `current`; backports via `@Mergifyio backport <branch>`.
-- Reusable workflows pinned `@current` — changes in `vyos/.github` ship immediately.
+- Default branch `rolling`; backports via `@Mergifyio backport <branch>`.
+- Reusable workflows pinned `@production` — changes in `vyos/.github` ship immediately.
 
 ## Notes for future contributors
 - This is a load-bearing library — every `commit` operation against VyOS goes through it. Add tests at the `libvyosconfig`/`vyos-1x` layers, not just locally.


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943) (the 1c rename that caused the drift).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)