### PR TITLE
T9182: simplify lexical_numeric_compare and catch corner case

### DIFF
--- a/src/lexical_numeric_compare.c
+++ b/src/lexical_numeric_compare.c
@@ -1,79 +1,43 @@
 /*
  * lexicographical-numeric compare
  */
-#include <string.h>
+
+#include <stdlib.h>
 #include <ctype.h>
+#include <string.h>
 #include <caml/mlvalues.h>
-#include <caml/fail.h>
+
+static int normalize(int v) {
+    return v == 0 ? 0 : (v / abs(v));
+}
 
 CAMLprim value caml_lex_numeric_compare(value str1, value str2) {
-    const char* inconsistent = "internal indexing error";
-    mlsize_t len, len1, len2;
-    int pos, pos1, pos2;
     const char * s1, * s2;
-    const char * p1, * p2;
-    int n1, n2;
-    int res;
 
-    if (str1 == str2) return Val_int(0);
-    len1 = caml_string_length(str1);
-    len2 = caml_string_length(str2);
-    len = len1 <= len2 ? len1 : len2;
     s1 = String_val(str1);
     s2 = String_val(str2);
-    p1 = s1;
-    p2 = s2;
-    pos = 0;
 
-    do {
-        while ((pos < len) && (!isdigit(*s1) || !isdigit(*s2))) {
-            s1++;
-            s2++;
-            pos++;
-        }
-        if (pos > 0) {
-            res = memcmp(p1, p2, pos);
-            if (res < 0) return Val_int(-1);
-            if (res > 0) return Val_int(1);
-            if (pos == len) {
-                if (len1 < len2) return Val_int(-1);
-                if (len2 < len1) return Val_int(1);
-                return Val_int(0);
+    while (*s1 && *s2) {
+        if (isdigit((unsigned char)*s1) && isdigit((unsigned char)*s2)) {
+            const char *ps1 = s1, *ps2 = s2;
+
+            while (isdigit((unsigned char)*s1)) s1++;
+            while (isdigit((unsigned char)*s2)) s2++;
+            size_t ls1 = s1 - ps1, ls2 = s2 - ps2;
+
+            if (ls1 != ls2) return ls1 < ls2 ? Val_int(-1) : Val_int(1);
+
+            int c = memcmp(ps1, ps2, ls1);
+            if (c) return Val_int(normalize(c));
+
+        } else {
+            if (*s1 != *s2) {
+                int res = (int)((unsigned char)*s1 - (unsigned char)*s2);
+                return Val_int(normalize(res));
             }
+            s1++; s2++;
         }
-        p1 = s1;
-        p2 = s2;
-        len = len - pos;
-        len1 = len1 - pos;
-        len2 = len2 - pos;
-        pos1 = pos2 = 0;
-        n1 = n2 = 0;
-        while ((pos1 < len1) && isdigit(*s1)) {
-            n1 = n1 * 10 + *s1 - '0';
-            s1++;
-            pos1++;
-        }
-        while ((pos2 < len2) && isdigit(*s2)) {
-            n2 = n2 * 10 + *s2 - '0';
-            s2++;
-            pos2++;
-        }
-        if (n1 < n2) return Val_int(-1);
-        if (n2 < n1) return Val_int(1);
-        if ((pos1 == len1) || (pos2 == len2)) {
-            if (len1 < len2) return Val_int(-1);
-            if (len2 < len1) return Val_int(1);
-            return Val_int(0);
-
-        }
-        // if a sequence of 0's were encountered, it is possible that
-        // pos1 != pos2; adjust
-        pos = pos1 > pos2 ? pos2 : pos1;
-        p1 = s1;
-        p2 = s2;
-        len = len - pos;
-        len1 = len1 - pos;
-        len2 = len2 - pos;
-        pos = 0;
-    } while (*s1 && *s2);
+    }
+    int res = (int)((unsigned char)*s1 - (unsigned char)*s2);
+    return Val_int(normalize(res));
 }


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Distill the ad-hoc logic of the original into a compact and readable form, fixing a missed corner case identified by automated review of https://github.com/vyos/vyos1x-config/pull/90#discussion_r3725468050

The advantage of keeping this in C is the (now) simple logic with the implicit use of the terminating null byte in the calculation, since (by construction) node names and tag/leaf values have no embedded null bytes.

By comparison, one can see a best of pure OCaml version here:
https://github.com/janestreet/numeric_string/blob/master/src/numeric_string.ml

As in the Jane Street example, we can consider adding an option to allow ignoring leading 0's. However, for our purposes we want a distinction in the case of arbitrary node name practices, such as "name1" and "name01". Equality of integer values is a matter for parsing/validation, not the comparator.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
